### PR TITLE
modified org page grid

### DIFF
--- a/components/Bounty/BountyHomepage.js
+++ b/components/Bounty/BountyHomepage.js
@@ -2,7 +2,6 @@
 import React, { useEffect, useState, useContext } from 'react';
 // Custom
 import StoreContext from '../../store/Store/StoreContext';
-import MintBountyButton from '../MintBounty/MintBountyButton';
 import BountyList from './BountyList';
 
 const BountyHomepage = () => {
@@ -44,12 +43,9 @@ const BountyHomepage = () => {
 	// Render
 	return (
 		<div className="flex justify-center items-center">
-			<div className="grid grid-cols-3 gap-3">
-				<MintBountyButton />
 
-				{isLoading ? null :
-					<BountyList bounties={bounties} />}
-			</div>
+			{isLoading ? null :
+				<BountyList bounties={bounties} />}
 		</div>
 	);
 };

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -7,6 +7,7 @@ import StoreContext from '../../store/Store/StoreContext';
 import BountyCard from './BountyCard';
 import Dropdown from '../Toggle/Dropdown';
 import SearchBar from '../Search/SearchBar';
+import MintBountyButton from '../MintBounty/MintBountyButton';
 
 const BountyList = ({ bounties }) => {
 	// Hooks
@@ -146,14 +147,18 @@ const BountyList = ({ bounties }) => {
 
 	// Render
 	return (
-		<div className="w-f space-y-3">
-			<div className="flex w-min rounded-lg z-10 relative"><SearchBar
-				onKeyUp={handleSearchInput}
-				placeholder={'Search Issue...'}
-				searchText={searchText}
-				borderShape={'border-b border-l rounded-l-lg border-t'}
-			/>
-			<Dropdown toggleFunc={addTag}  title="Filter By Label" names={availableLabels} borderShape={'rounded-r-lg'}/></div>	
+		<div className="sm:w-2/3 space-y-3">			
+			<div className="grid lg:grid-cols-[repeat(4,_1fr)] gap-6">
+				<div className="flex rounded-lg z-10 relative lg:col-span-3 col-span-4">
+					<SearchBar
+						onKeyUp={handleSearchInput}
+						placeholder={'Search Issue...'}
+						searchText={searchText}
+						borderShape={'border-b border-l rounded-l-lg border-t'}
+					/>
+					<Dropdown toggleFunc={addTag}  title="Filter By Label" names={availableLabels} borderShape={'rounded-r-lg'}/></div>	
+				<MintBountyButton />
+			</div>
 			<div className="flex flex-wrap content-center items-center flex-row items-start gap-4">
 				<div className="flex bg-dark-modegap-2  rounded-md">
 					<span className="text-white p-2  align-self-center pr-4">Sort By</span>

--- a/components/MintBounty/MintBountyButton.js
+++ b/components/MintBounty/MintBountyButton.js
@@ -11,7 +11,7 @@ const MintBountyButton = () => {
 		<>
 			<button
 				onClick={() => setShowModal(true)}
-				className="col-start-1 lg:col-start-8 md:col-start-6 sm:col-start-4 font-mont w-full rounded-lg border border-web-gray py-2 px-6 text-white font-semibold cursor-pointer hover:border-white"
+				className="lg:col-start-4 col-span-4 lg:col-span-1 whitespace-nowrap font-mont rounded-lg border border-web-gray py-2 px-6 text-white font-semibold cursor-pointer hover:border-white"
 			>
 				Mint Bounty
 			</button>

--- a/components/MintBounty/MintBountyButton.js
+++ b/components/MintBounty/MintBountyButton.js
@@ -11,7 +11,7 @@ const MintBountyButton = () => {
 		<>
 			<button
 				onClick={() => setShowModal(true)}
-				className="col-span-3 font-mont w-full rounded-lg border border-web-gray py-2 px-6 text-white font-semibold cursor-pointer hover:border-white"
+				className="col-start-1 lg:col-start-8 md:col-start-6 sm:col-start-4 font-mont w-full rounded-lg border border-web-gray py-2 px-6 text-white font-semibold cursor-pointer hover:border-white"
 			>
 				Mint Bounty
 			</button>

--- a/components/Organization/OrganizationCard.js
+++ b/components/Organization/OrganizationCard.js
@@ -5,7 +5,11 @@ import Image from 'next/image';
 
 const OrganizationCard = ({ organization }) => {
 	// Context
-	const orgName = organization.name.charAt(0).toUpperCase() + organization.name.slice(1);
+	let orgName = organization.name.charAt(0).toUpperCase() + organization.name.slice(1);
+	
+	if(orgName.length>11){
+		orgName=orgName.slice(0,10).concat('...');
+	}
 
 	// Methods
 

--- a/components/Organization/OrganizationHomepage.js
+++ b/components/Organization/OrganizationHomepage.js
@@ -62,10 +62,11 @@ const OrganizationHomepage = () => {
 	// Render
 	return (
 		<div>
-			<div className="flex justify-center">
-				<div className="grid gap-3 content-center">
+			<div className="">
+				<div className="grid gap-6 lg:grid-cols-[repeat(4,_1fr)] sm:w-2/3 mb-6 mx-auto">
 					<SearchBar onKeyUp={filterByOrg} searchText={organizationSearchTerm} placeholder="Search Organization..." borderShape={'border rounded-full'} className="mb-200" />
-					<MintBountyButton />
+					<MintBountyButton /></div>
+				<div className="grid grid-cols-[repeat(_auto-fit,_192px)] gap-6 justify-center sm:justify-start w-2/3 mx-auto">
 					{isLoading
 						? null
 						: organizations
@@ -78,7 +79,7 @@ const OrganizationHomepage = () => {
 							})
 							.map((organization) => {
 								return (
-									<div className="col-span-2 w-48" key={organization.id}>
+									<div className="w-48" key={organization.id}>
 										<OrganizationCard
 											organization={organization}
 											key={organization.id}

--- a/components/Organization/OrganizationHomepage.js
+++ b/components/Organization/OrganizationHomepage.js
@@ -63,7 +63,7 @@ const OrganizationHomepage = () => {
 	return (
 		<div>
 			<div className="flex justify-center">
-				<div className="grid grid-cols-3 gap-3">
+				<div className="grid gap-3 content-center">
 					<SearchBar onKeyUp={filterByOrg} searchText={organizationSearchTerm} placeholder="Search Organization..." borderShape={'border rounded-full'} className="mb-200" />
 					<MintBountyButton />
 					{isLoading
@@ -78,7 +78,7 @@ const OrganizationHomepage = () => {
 							})
 							.map((organization) => {
 								return (
-									<div className="col-span-3 md:col-span-1" key={organization.id}>
+									<div className="col-span-2 w-48" key={organization.id}>
 										<OrganizationCard
 											organization={organization}
 											key={organization.id}

--- a/components/Search/SearchBar.js
+++ b/components/Search/SearchBar.js
@@ -4,7 +4,7 @@ import React from 'react';
 const SearchBar = ({ onKeyUp, placeholder, searchText, borderShape }) => {
 	return (
 		<input
-			className={`col-span-3 outline-none font-mont py-2 p-5 ${borderShape} border-web-gray bg-dark-mode text-white`}
+			className={`col-start-1 col-end-2 lg:col-end-8 md:col-end-6 sm:col-end-4 outline-none font-mont py-2 p-5 ${borderShape} border-web-gray bg-dark-mode text-white`}
 			onChange={(e) => onKeyUp(e)} value={searchText}
 			type="text"
 			placeholder={placeholder}

--- a/components/Search/SearchBar.js
+++ b/components/Search/SearchBar.js
@@ -4,7 +4,7 @@ import React from 'react';
 const SearchBar = ({ onKeyUp, placeholder, searchText, borderShape }) => {
 	return (
 		<input
-			className={`col-start-1 col-end-2 lg:col-end-8 md:col-end-6 sm:col-end-4 outline-none font-mont py-2 p-5 ${borderShape} border-web-gray bg-dark-mode text-white`}
+			className={`flex-1 lg:col-span-3 col-span-4 outline-none font-mont py-2 p-5 ${borderShape} border-web-gray bg-dark-mode text-white`}
 			onChange={(e) => onKeyUp(e)} value={searchText}
 			type="text"
 			placeholder={placeholder}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -67,6 +67,7 @@ module.exports = {
 		},
 		gridTemplateColumns: {
 			'wide': '1fr 2fr 1fr',
+			'annoying': 'repeat( auto-fit, 192px)',
 		}
 	},
 	variants: {


### PR DESCRIPTION
**INCOMPLETE**

Modifies the org page grid to @rikkdev 's specifications. Here's a screenshot of what it looks like 
![image](https://user-images.githubusercontent.com/72156679/156908676-5d7545a1-0a7d-45db-b023-54560ff4d4b5.png) Is that what your looking for? I have to look into it a little more as currently this breaks the issue page.
I had to hard code grid styles in the search bar for each breakpoint of the grid, which was unfortunate, but I didn't see a better way. Let me know if you'd like to pass the grid styles to SearchBar and MintBounty as props.