### PR TITLE
Modifies claimed deposits and removes slate bg-color on token search

### DIFF
--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -49,14 +49,15 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 							return (parseInt(a.receiveTime) + parseInt(a.expiration)) - (parseInt(b.receiveTime) + parseInt(b.expiration));
 						})
 						.map((deposit) => {
+							const open=(bounty.status==='OPEN');
 							const timeToExpiry = parseInt(deposit.receiveTime)+parseInt(deposit.expiration)-Date.now()*0.001;		
 							return (
-								<div key={deposit.id} className={`bg-web-gray/20 ${timeToExpiry<604800?'border-red-500': timeToExpiry <1209600 ? 'border-yellow-500' :'border-green-500' } border px-8 my-4 pb-4 rounded-md max-w-sm`}>
+								<div key={deposit.id} className={`bg-web-gray/20 ${(open) ? timeToExpiry<604800?'border-red-500': timeToExpiry <1209600 ? 'border-yellow-500' :'border-green-500' : 'border-web-gray'} border px-8 my-4 pb-4 rounded-md max-w-sm`}>
 									<TokenBalances 
 										tokenBalances={[deposit]}
 										tokenValues={tokenValues} />
-									<div key={deposit.id} className='text-white'>Locked until: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime) + parseInt(deposit.expiration))}</div>
-								</div>
+									{(open) && <div key={deposit.id} className='text-white'>Locked until: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime) + parseInt(deposit.expiration))}</div>
+									}		</div>
 							);
 						})
 					}

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -57,7 +57,8 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 										tokenBalances={[deposit]}
 										tokenValues={tokenValues} />
 									{(open) && <div key={deposit.id} className='text-white'>Locked until: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime) + parseInt(deposit.expiration))}</div>
-									}		</div>
+									}
+								</div>
 							);
 						})
 					}

--- a/components/FundBounty/SearchTokens/TokenList.js
+++ b/components/FundBounty/SearchTokens/TokenList.js
@@ -13,11 +13,11 @@ const TokenList = ({ onCurrencySelect, setShowTokenSearch }) => {
 	return (
 		<div>
 			{/* <div style={{ padding: '25px', margin: '10px', outline: '2px solid pink', borderRadius: '20px' }} > */}
-			<div className="pt-3 pb-3 pl-4 bg-slate-700 border border-web-gray bg-dark-mode rounded-lg overflow-hidden mb-2">
+			<div className="pt-3 pb-3 pl-4 bg-dark-mode border border-web-gray rounded-lg overflow-hidden mb-2">
 				<div className="">
-					<div className="justify-start bg-dark-mode">
+					<div className="justify-start ">
 						<input
-							className="outline-none bg-dark-mode text-white"
+							className="outline-none bg-transparent text-white"
 							onKeyUp={(e) => setTokenSearchTerm(e.target.value)}
 							type="text"
 							placeholder="Search name"

--- a/components/FundBounty/SearchTokens/TokenSearch.js
+++ b/components/FundBounty/SearchTokens/TokenSearch.js
@@ -10,7 +10,7 @@ const TokenSearch = ({ setShowTokenSearch, onCurrencySelect }) => {
 		<div>
 			<div onClick={handleOutsideClick} className="justify-center font-mont items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
 				<div className="max-w-full w-72">
-					<div onClick={(e)=>e.stopPropagation()} className="flex justify-left border-0 pl-8 pr-8 pt-5 pb-3 rounded-lg shadow-lg flex flex-col w-full bg-dark-mode outline-none focus:outline-none">
+					<div onClick={(e)=>e.stopPropagation()} className="flex justify-left border border-web-gray pl-8 pr-8 pt-5 pb-3 rounded-lg shadow-lg flex flex-col w-full bg-dark-mode outline-none focus:outline-none">
 						<div className="flex items-start justify-between border-solid rounded-t">
 							<h3 className="text-1xl font-semibold text-white">
                 Select a Token


### PR DESCRIPTION
Fixes #98.Replaces coloured border with "web-gray" colour.
![image](https://user-images.githubusercontent.com/72156679/157111609-ab292aa6-0a4e-4cdd-8a88-73fcf54a77a9.png)
Fixes #97 makes token search bg-color the normal bg-color. Also adds a border around token search for readability. 
![image](https://user-images.githubusercontent.com/72156679/157113990-3ae0fa7f-dad6-47ec-9a3f-0bf5fcde6501.png)

