### PR TITLE
Chris

### DIFF
--- a/components/Bounty/BountyHomepage.js
+++ b/components/Bounty/BountyHomepage.js
@@ -42,7 +42,7 @@ const BountyHomepage = () => {
 
 	// Render
 	return (
-		<div className="flex justify-center items-center">
+		<div className="grid xl:grid-cols-wide justify-center">
 
 			{isLoading ? null :
 				<BountyList bounties={bounties} />}

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -147,7 +147,7 @@ const BountyList = ({ bounties }) => {
 
 	// Render
 	return (
-		<div className="sm:w-2/3 space-y-3">			
+		<div className="xl:col-start-2 max-w-screen-md space-y-3 px-5">			
 			<div className="grid lg:grid-cols-[repeat(4,_1fr)] gap-6">
 				<div className="flex rounded-lg z-10 relative lg:col-span-3 col-span-4">
 					<SearchBar

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -147,7 +147,7 @@ const BountyList = ({ bounties }) => {
 
 	// Render
 	return (
-		<div className="xl:col-start-2 max-w-screen-md space-y-3 px-5">			
+		<div className="xl:col-start-2 justify-self-center max-w-screen-md space-y-3 px-5">			
 			<div className="grid lg:grid-cols-[repeat(4,_1fr)] gap-6">
 				<div className="flex rounded-lg z-10 relative lg:col-span-3 col-span-4">
 					<SearchBar

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -15,7 +15,7 @@ const BountyList = ({ bounties }) => {
 	const [issueTitleSearchTerm, setIssueTitleSearchTerm] = useState('');
 	const [displayBounties, updateDisplayBounties] = useState([]);
 	const [tvlBounties, updateTvlBounties] = useState([]);
-	const [unfundedVisible, setUnfundedVisible] = useState(true);
+	const [unfundedVisible, setUnfundedVisible] = useState(false);
 	const [claimedVisible, setClaimedVisible] = useState(false);
 	const [sortOrder, updateSortOrder] = useState('Newest');
 	const [tagArr, updateTagArr] = useState([]);

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -159,16 +159,16 @@ const BountyList = ({ bounties }) => {
 					<Dropdown toggleFunc={addTag}  title="Filter By Label" names={availableLabels} borderShape={'rounded-r-lg'}/></div>	
 				<MintBountyButton />
 			</div>
-			<div className="flex flex-wrap content-center justify-center md:justify-start flex-row gap-4">
+			<div className="flex md:content-start content-center flex-col gap-2">
 				<div className="flex bg-dark-mode justify-between rounded-md w-64">
 					<span className="text-white p-2  align-self-center pr-4">Sort By</span>
 					<Dropdown toggleFunc={orderBounties} toggleVal={sortOrder} names={['Newest', 'Oldest', 'Highest\xa0TVL', 'Lowest\xa0TVL']} borderShape={'rounded-md'}/>
 				</div>
-				<div className="flex p-2 gap-2 border rounded-md border-web-gray w-64">
+				<div className="flex p-2 pr-4 gap-2 border rounded-md justify-between border-web-gray w-64">
 					<label htmlFor="unfunded" className="text-white">Show Unfunded Bounties</label>
 					<input id="unfunded" type="checkbox" className="accent-pink-500" onChange={showUnfunded} />
 				</div>
-				<div className="flex p-2 gap-2 border rounded-md border-web-gray w-64">
+				<div className="flex p-2 pr-4 gap-2 border rounded-md justify-between border-web-gray w-64">
 					<label htmlFor="claimed" className="text-white" >Show Claimed Bounties</label>
 					<input id="claimed" type="checkbox" className="accent-pink-500" onChange={showClaimed} />
 				</div>

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -159,16 +159,16 @@ const BountyList = ({ bounties }) => {
 					<Dropdown toggleFunc={addTag}  title="Filter By Label" names={availableLabels} borderShape={'rounded-r-lg'}/></div>	
 				<MintBountyButton />
 			</div>
-			<div className="flex flex-wrap content-center items-center flex-row items-start gap-4">
-				<div className="flex bg-dark-modegap-2  rounded-md">
+			<div className="flex flex-wrap content-center justify-center md:justify-start flex-row gap-4">
+				<div className="flex bg-dark-mode justify-between rounded-md w-64">
 					<span className="text-white p-2  align-self-center pr-4">Sort By</span>
 					<Dropdown toggleFunc={orderBounties} toggleVal={sortOrder} names={['Newest', 'Oldest', 'Highest\xa0TVL', 'Lowest\xa0TVL']} borderShape={'rounded-md'}/>
 				</div>
-				<div className="flex p-2 gap-2 border rounded-md border-web-gray">
+				<div className="flex p-2 gap-2 border rounded-md border-web-gray w-64">
 					<label htmlFor="unfunded" className="text-white">Show Unfunded Bounties</label>
 					<input id="unfunded" type="checkbox" className="accent-pink-500" onChange={showUnfunded} />
 				</div>
-				<div className="flex p-2 gap-2 border rounded-md border-web-gray">
+				<div className="flex p-2 gap-2 border rounded-md border-web-gray w-64">
 					<label htmlFor="claimed" className="text-white" >Show Claimed Bounties</label>
 					<input id="claimed" type="checkbox" className="accent-pink-500" onChange={showClaimed} />
 				</div>

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -32,7 +32,7 @@ const Layout = ({ children }) => {
 						<div className="pr-5">
 							<ConnectButton />
 						</div>
-						<div className="w-9 pt-1">
+						<div className="w-9">
 							<ProfilePicture />
 						</div>
 					</div>

--- a/components/Organization/LargeOrganizationCard.js
+++ b/components/Organization/LargeOrganizationCard.js
@@ -9,7 +9,7 @@ const LargeOrganizationCard = ({ organization }) => {
 
 	// Render
 	return (
-		<div className='w-min justify-self-end hidden md:block'>
+		<div className='w-min justify-self-end hidden xl:block'>
 			<div
 				className={
 					'flex flex-col p-10 items-center font-mont rounded-lg shadow-sm border border-web-gray pr-11 pl-11'

--- a/components/Organization/OrganizationCard.js
+++ b/components/Organization/OrganizationCard.js
@@ -7,8 +7,8 @@ const OrganizationCard = ({ organization }) => {
 	// Context
 	let orgName = organization.name.charAt(0).toUpperCase() + organization.name.slice(1);
 	
-	if(orgName.length>11){
-		orgName=orgName.slice(0,10).concat('...');
+	if(orgName.length>10){
+		orgName=orgName.slice(0, 9).concat('...');
 	}
 
 	// Methods

--- a/components/Organization/OrganizationHomepage.js
+++ b/components/Organization/OrganizationHomepage.js
@@ -62,7 +62,7 @@ const OrganizationHomepage = () => {
 	// Render
 	return (
 		<div>
-			<div className="">
+			<div className="max-w-screen-xl mx-auto">
 				<div className="grid gap-6 lg:grid-cols-[repeat(4,_1fr)] sm:w-2/3 mb-6 mx-auto">
 					<SearchBar onKeyUp={filterByOrg} searchText={organizationSearchTerm} placeholder="Search Organization..." borderShape={'border rounded-full'} className="mb-200" />
 					<MintBountyButton /></div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,7 +40,7 @@ export default function Index() {
 							</button>
 						</div>
 					</div>
-					<div className="px-5 md:px-14">
+					<div>
 						{internalMenu == 'org' ? <OrganizationHomepage /> : <BountyHomepage />}
 					</div>
 				</div>

--- a/pages/organization/[organization].js
+++ b/pages/organization/[organization].js
@@ -76,11 +76,11 @@ const organization = () => {
 		return 'Loading...';
 	} else {
 		return (
-			<div className="bg-dark-mode">
+			<div className="bg-dark-mode pt-10">
 				<Toggle toggleFunc={setShowAbout} toggleVal={showAbout} names={['Bounties', 'About']} />
 				{(showAbout === 'About') ?
 					<About organizationData={organizationData} tokenValues={tokenValues} /> :
-					<div className="grid px-10 md:grid-cols-wide justify-center w-f gap-8 pt-10">
+					<div className="grid xl:grid-cols-wide justify-center w-f pt-8">
 						<LargeOrganizationCard organization={organizationData} />
 						<BountyList bounties={bounties} />
 					</div>}


### PR DESCRIPTION
Fixes #100  Fixes #101 Fixes #102 Fixes #103.
I switched the filtering and sorting ui to always stacking as per requested, but that uses a lot of vertical space. Might be better to let the filtering cards sit on the same line. 
I also prevented the mint button from getting squished by sticking it on the next line on breakpoints below 1155 px, so that maybe an issue as that makes for a large button.
`[organization]`:
![image](https://user-images.githubusercontent.com/72156679/157283386-8e53b85a-3c66-42e3-be94-1406b1e16ea3.png)
`BountyHomepage`:
![image](https://user-images.githubusercontent.com/72156679/157283322-3982c594-b1d1-4844-a098-19f23d0571c6.png)
