### PR TITLE
Fixes Deposit token balances showing total per-token bounty TVL rather than per-deposit TVL

### DIFF
--- a/components/About/AboutFunding.js
+++ b/components/About/AboutFunding.js
@@ -9,6 +9,7 @@ const AboutFunding = ({ organizationFunding, tokenValues }) => {
 					tokenBalances={organizationFunding}
 					tokenValues={tokenValues}
 					header={'Current Total Value Locked'}
+					singleCurrency={false}
 				/>
 			</ul>
 		</dt>

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -35,6 +35,7 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 						header={bounty.status == 'CLOSED' ? 'Total Value Claimed' : 'Current Total Value Locked'}
 						tokenBalances={bounty.bountyTokenBalances}
 						tokenValues={tokenValues}
+						singleCurrency={false}
 					/>
 				) : (
 					<div className="pt-5 pb-5 font-semibold text-white">No deposits</div>
@@ -49,13 +50,15 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 							return (parseInt(a.receiveTime) + parseInt(a.expiration)) - (parseInt(b.receiveTime) + parseInt(b.expiration));
 						})
 						.map((deposit) => {
-							const open=(bounty.status==='OPEN');
-							const timeToExpiry = parseInt(deposit.receiveTime)+parseInt(deposit.expiration)-Date.now()*0.001;		
+							const open = (bounty.status === 'OPEN');
+							const timeToExpiry = parseInt(deposit.receiveTime) + parseInt(deposit.expiration) - Date.now() * 0.001;
 							return (
-								<div key={deposit.id} className={`bg-web-gray/20 ${(open) ? timeToExpiry<604800?'border-red-500': timeToExpiry <1209600 ? 'border-yellow-500' :'border-green-500' : 'border-web-gray'} border px-8 my-4 pb-4 rounded-md max-w-sm`}>
-									<TokenBalances 
+								<div key={deposit.id} className={`bg-web-gray/20 ${(open) ? timeToExpiry < 604800 ? 'border-red-500' : timeToExpiry < 1209600 ? 'border-yellow-500' : 'border-green-500' : 'border-web-gray'} border px-8 my-4 pb-4 rounded-md max-w-sm`}>
+									<TokenBalances
 										tokenBalances={[deposit]}
-										tokenValues={tokenValues} />
+										tokenValues={tokenValues}
+										singleCurrency={true}
+									/>
 									{(open) && <div key={deposit.id} className='text-white'>Locked until: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime) + parseInt(deposit.expiration))}</div>
 									}
 								</div>

--- a/components/Organization/OrganizationCard.js
+++ b/components/Organization/OrganizationCard.js
@@ -6,9 +6,9 @@ import Image from 'next/image';
 const OrganizationCard = ({ organization }) => {
 	// Context
 	let orgName = organization.name.charAt(0).toUpperCase() + organization.name.slice(1);
-	
-	if(orgName.length>10){
-		orgName=orgName.slice(0, 9).concat('...');
+
+	if (orgName.length > 10) {
+		orgName = orgName.slice(0, 9).concat('...');
 	}
 
 	// Methods
@@ -39,19 +39,6 @@ const OrganizationCard = ({ organization }) => {
 							: 'Bounties'
 						}`}
 					</div>
-					{/* <div>
-						{tokenValues ? (
-							<TokenBalances
-								tokenBalances={organization.fundedTokenBalances}
-								tokenValues={tokenValues}
-							/>
-						) : null}
-					</div>
-					<div>
-						{tokenValues ? (
-							<div>{appState.utils.formatter.format(tokenValues.total)}</div>
-						) : null}
-					</div> */}
 				</div>
 			</Link>
 		</div>

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -9,30 +9,31 @@ const DepositCard = ({ deposit, refundBounty, status }) => {
 
 	// State
 	const [tokenValues] = useGetTokenValues(deposit);
+	console.log(deposit);
 
 	return (
-		<div className={`flex flex-col items-start px-8 sm:px-6 pb-4 max-w-sm bg-web-gray/20 ${status==='refundable'? ' border-pink-300' : status==='not-yet-refundable'?' border-green-500':' border-web-gray'} border rounded-md`}>
-			<TokenBalances 
+		<div className={`flex flex-col items-start px-8 sm:px-6 pb-4 max-w-sm bg-web-gray/20 ${status === 'refundable' ? ' border-pink-300' : status === 'not-yet-refundable' ? ' border-green-500' : ' border-web-gray'} border rounded-md`}>
+			<TokenBalances
 				tokenBalances={deposit}
 				tokenValues={tokenValues} />
 			<div className="text-left text-white pb-4">
-					Deposited on: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime))}
+				Deposited on: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime))}
 			</div>
 			{deposit.refunded ?
 				(<div className="text-left text-white pb-2">
-						Refunded on: {appState.utils.formatUnixDate(parseInt(deposit.refundTime))}
+					Refunded on: {appState.utils.formatUnixDate(parseInt(deposit.refundTime))}
 				</div>)
 				:
 				(<div className="text-left text-white pb-2">
-						Refundable on: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime) + parseInt(deposit.expiration))}
+					Refundable on: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime) + parseInt(deposit.expiration))}
 				</div>)
 			}
-			{status==='refundable' &&
-			<button  className='items-left w-1/2 text-lg text-white self-center sm-confirm-btn'  onClick={() => refundBounty(deposit.id)}>
+			{status === 'refundable' &&
+				<button className='items-left w-1/2 text-lg text-white self-center sm-confirm-btn' onClick={() => refundBounty(deposit.id)}>
 					Refund
-			</button>}
+				</button>}
 		</div>
-		
+
 	);
 };
 

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -15,7 +15,9 @@ const DepositCard = ({ deposit, refundBounty, status }) => {
 		<div className={`flex flex-col items-start px-8 sm:px-6 pb-4 max-w-sm bg-web-gray/20 ${status === 'refundable' ? ' border-pink-300' : status === 'not-yet-refundable' ? ' border-green-500' : ' border-web-gray'} border rounded-md`}>
 			<TokenBalances
 				tokenBalances={deposit}
-				tokenValues={tokenValues} />
+				tokenValues={tokenValues}
+				singleCurrency={false}
+			/>
 			<div className="text-left text-white pb-4">
 				Deposited on: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime))}
 			</div>

--- a/components/TokenBalances/TokenBalances.js
+++ b/components/TokenBalances/TokenBalances.js
@@ -6,17 +6,17 @@ const ethers = require('ethers');
 
 const TokenBalances = ({ tokenBalances, tokenValues, header }) => {
 	const [appState] = useContext(StoreContext);
-	const tokenBalancesArr=Array.isArray(tokenBalances) ? tokenBalances:[tokenBalances];
+	const tokenBalancesArr = Array.isArray(tokenBalances) ? tokenBalances : [tokenBalances];
 	const { tokenMetadata } = appState;
 
 	return (
 		<div className="flex flex-col pt-2 pb-2">
 			<div className="font-semibold text-white">{header}</div>
 			<div className="font-bold text-xl text-white">
-				{tokenBalances.length > 1 
-					? tokenValues 
+				{tokenBalances.length > 1
+					? tokenValues
 						? `${appState.utils.formatter.format(tokenValues.total)}`
-						: `${appState.utils.formatter.format(0)}`:null}
+						: `${appState.utils.formatter.format(0)}` : null}
 			</div>
 			<div className="flex flex-row space-x-2 pt-1">
 				<div>
@@ -29,9 +29,13 @@ const TokenBalances = ({ tokenBalances, tokenValues, header }) => {
 
 							const { volume } = tokenBalance;
 							let symbol = tokenMetadata[tokenAddress].symbol;
+
 							let usdValue = appState.utils.formatter.format(
 								tokenValues.tokens[tokenValueAddress.toLowerCase()]
 							);
+
+							let formattedVolume = ethers.utils.formatUnits(
+								ethers.BigNumber.from(volume.toString()), parseInt(tokenMetadata[tokenAddress].decimals));
 
 							return (
 								<div
@@ -48,10 +52,7 @@ const TokenBalances = ({ tokenBalances, tokenValues, header }) => {
 									</div>
 									<div className="text-lg text-white">{usdValue}</div>{' '}
 									<div className="text-lg text-white">
-										(
-										{ethers.utils.formatUnits(
-											ethers.BigNumber.from(volume.toString()), parseInt(tokenMetadata[tokenAddress].decimals)
-										)}{'\xa0'}
+										{formattedVolume}{'\xa0'}
 										{symbol.toUpperCase()})
 									</div>
 

--- a/components/TokenBalances/TokenBalances.js
+++ b/components/TokenBalances/TokenBalances.js
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import StoreContext from '../../store/Store/StoreContext';
 const ethers = require('ethers');
 
-const TokenBalances = ({ tokenBalances, tokenValues, header }) => {
+const TokenBalances = ({ tokenBalances, tokenValues, header, singleCurrency }) => {
 	const [appState] = useContext(StoreContext);
 	const tokenBalancesArr = Array.isArray(tokenBalances) ? tokenBalances : [tokenBalances];
 	const { tokenMetadata } = appState;
@@ -30,12 +30,21 @@ const TokenBalances = ({ tokenBalances, tokenValues, header }) => {
 							const { volume } = tokenBalance;
 							let symbol = tokenMetadata[tokenAddress].symbol;
 
-							let usdValue = appState.utils.formatter.format(
-								tokenValues.tokens[tokenValueAddress.toLowerCase()]
-							);
+							let bigNumberVolume = ethers.BigNumber.from(volume.toString());
+							let decimals = parseInt(tokenMetadata[tokenAddress].decimals);
 
-							let formattedVolume = ethers.utils.formatUnits(
-								ethers.BigNumber.from(volume.toString()), parseInt(tokenMetadata[tokenAddress].decimals));
+							let formattedVolume = ethers.utils.formatUnits(bigNumberVolume, decimals);
+
+							let totalValue;
+							if (!singleCurrency) {
+								totalValue = tokenValues.tokens[tokenValueAddress.toLowerCase()];
+							} else {
+								totalValue = formattedVolume * tokenValues.tokenPrices[tokenValueAddress.toLowerCase()];
+							}
+
+							let usdValue = appState.utils.formatter.format(
+								totalValue
+							);
 
 							return (
 								<div
@@ -53,7 +62,7 @@ const TokenBalances = ({ tokenBalances, tokenValues, header }) => {
 									<div className="text-lg text-white">{usdValue}</div>{' '}
 									<div className="text-lg text-white">
 										{formattedVolume}{'\xa0'}
-										{symbol.toUpperCase()})
+										{symbol.toUpperCase()}
 									</div>
 
 								</div>

--- a/hooks/useGetTokenValues.js
+++ b/hooks/useGetTokenValues.js
@@ -20,7 +20,7 @@ const useGetTokenValues = (tokenBalances) => {
 				const tokenAddress = appState.tokenMetadata[ethers.utils.getAddress(tokenBalances.tokenAddress)].address;
 				tokenVolumes[tokenAddress] = tokenBalances.volume;
 			}
-			const data = { tokenVolumes, network: "polygon-pos" };
+			const data = { tokenVolumes, network: 'polygon-pos' };
 			const url = process.env.NEXT_PUBLIC_COIN_API_URL + '/tvl';
 			//only query tvl for bounties that have deposits
 			if (JSON.stringify(data.tokenVolumes) != '{}') {

--- a/hooks/useGetTokenValues.js
+++ b/hooks/useGetTokenValues.js
@@ -7,20 +7,20 @@ const useGetTokenValues = (tokenBalances) => {
 	const [appState] = useContext(StoreContext);
 
 	async function getTokenValues(tokenBalances) {
-		
+
 		if (tokenBalances != null) {
 			let tokenVolumes = {};
-			if(Array.isArray(tokenBalances)){
+			if (Array.isArray(tokenBalances)) {
 				tokenBalances.map((tokenBalance) => {
 					const tokenAddress = appState.tokenMetadata[ethers.utils.getAddress(tokenBalance.tokenAddress)].address;
 					tokenVolumes[tokenAddress] = tokenBalance.volume;
 				});
 			}
-			else{
+			else {
 				const tokenAddress = appState.tokenMetadata[ethers.utils.getAddress(tokenBalances.tokenAddress)].address;
 				tokenVolumes[tokenAddress] = tokenBalances.volume;
 			}
-			const data = { tokenVolumes };
+			const data = { tokenVolumes, network: "polygon-pos" };
 			const url = process.env.NEXT_PUBLIC_COIN_API_URL + '/tvl';
 			//only query tvl for bounties that have deposits
 			if (JSON.stringify(data.tokenVolumes) != '{}') {


### PR DESCRIPTION
Galvanized me to fix up CoinAPI at long last.

It now has a much more dynamic API which returns:
- individual token prices by address
- total tvl per token
- total overall price

Example Request:
```
{
    "tokenVolumes": {
        "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39": 2000000000000000000,
        "0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4": 2000000000000000000
    },
    "network": "polygon-pos"
}
```

Example Response:
```
{
    "tokenPrices": {
        "0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4": 2.39,
        "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39": 13.28
    },
    "tokens": {
        "0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4": 4.78,
        "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39": 26.56
    },
    "total": 31.34
}
```

Using this new API, I multiply the total formatted volume for that deposit by the individual token price