### PR TITLE
Chris

### DIFF
--- a/components/Bounty/BountyLinks.js
+++ b/components/Bounty/BountyLinks.js
@@ -1,15 +1,13 @@
 // Third Party
 import React from 'react';
 import Link from 'next/link';
-import {useRouter} from 'next/router';
 import Skeleton from 'react-loading-skeleton';
 import Image from 'next/image';
 
 // Custom
 
 const BountyLinks = ({ bounty, hideBountyLink }) => {
-	const router = useRouter();
-	const tweetText = router.query.first ? `I\'ve just created a bounty ${bounty?.twitterUsername ? `for %40${bounty.twitterUsername} `:''}on the OpenQ platform by @openqlabs! Check it out at ` : 'Check out this bounty on the OpenQ platform by @openqlabs! ';
+	const tweetText = `Check out this bounty ${bounty?.owner && `for ${bounty?.owner}`} on OpenQ. You can claim it just by making a pull requesting that completes the issue! `;
 	return (
 		<div className="flex flex-row font-bold text-xl space-x-4">
 			{!hideBountyLink ? bounty ? <Link

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -223,7 +223,7 @@ const BountyList = ({ bounties, loading, complete, getMoreData, getNewData }) =>
 					</div>
 					<div onClick={showClaimed} className="flex p-2 w-32 pr-4 gap-2 border rounded-md justify-between border-web-gray">
 						<label htmlFor="claimed" className="text-white pointer-events-none" >Claimed</label>
-						<input id="claimed" onChange={showUnfunded} type="checkbox" className="h-6 bg-no-repeat appearance-none w-4 h-4 checked:bg-inactive-accent checked:bg-[url('/checkbox.svg')] focus:outline-none border-2 border-web-gray checked:border-inactive-accent rounded-sm
+						<input id="claimed" onChange={showClaimed} type="checkbox" className="h-6 bg-no-repeat appearance-none w-4 h-4 checked:bg-inactive-accent checked:bg-[url('/checkbox.svg')] focus:outline-none border-2 border-web-gray checked:border-inactive-accent rounded-sm
 						m-1 bg-dark-mode accent-inactive-accent" checked={claimedVisible}/>
 					</div>
 				</div>

--- a/components/FundBounty/ApproveTransferModal.js
+++ b/components/FundBounty/ApproveTransferModal.js
@@ -1,5 +1,5 @@
 // Third Party
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 
 // Custom
 import {
@@ -21,11 +21,28 @@ const ApproveTransferModal = ({
 	positiveOption,
 	confirmMethod
 }) => {
-
+	const modal= useRef();
 	const updateModal = () => {
 		resetState();
 		setShowApproveTransferModal(false);
 	};
+
+	
+	useEffect(() => {
+		// Courtesy of https://stackoverflow.com/questions/32553158/detect-click-outside-react-component
+		function handleClickOutside(event) {
+			if (modal.current && !modal.current.contains(event.target)) {
+				updateModal();				
+			}
+		}
+
+		// Bind the event listener
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => {
+			// Unbind the event listener on clean up
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, [modal]);
 
 	let title = {
 		[CONFIRM]: 'Confirm',
@@ -45,8 +62,8 @@ const ApproveTransferModal = ({
 
 	return (
 		<div>
-			<div onClick={() => {if(approveTransferState!==TRANSFERRING) updateModal();}} className="justify-center items-center font-mont flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
-				<div className="w-1/4">
+			<div className="justify-center items-center font-mont flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
+				<div ref={modal} className="w-1/4">
 					<div className="border-0 rounded-lg p-7 shadow-lg flex flex-col w-full bg-dark-mode outline-none focus:outline-none">
 						<div className="flex items-center justify-center border-solid">
 							<div className="flex flex-row">

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -63,8 +63,13 @@ const FundPage = ({ bounty, refreshBounty }) => {
 
 		try {
 			const callerBalance = await appState.openQClient.balanceOf(library, account, token.address);
-
-			if (callerBalance.lt(bigNumberVolumeInWei)) {
+			if(callerBalance.noSigner){
+				const title = 'No wallet connected.';
+				const message = 'Please connect your wallet.';
+				setError({ message, title });
+				setApproveTransferState(ERROR);
+				return;
+			} else if (callerBalance.lt(bigNumberVolumeInWei)) {
 				const title = 'Funds Too Low';
 				const message = 'You do not have sufficient funds for this deposit';
 				setError({ message, title });

--- a/pages/auth/github.js
+++ b/pages/auth/github.js
@@ -43,8 +43,10 @@ function GitHubAuth() {
 	};
 
 	return (
-		<div>
-			Authenticating with GitHub...
+		<div className='flex fixed inset-0 justify-center'>
+			<div className='text-white h-min self-center'>
+			Authenticating with GitHub. You will be redirected to the Claim page once we{'\''}re done.
+			</div>
 		</div>
 	);
 }

--- a/services/ethers/OpenQClient.js
+++ b/services/ethers/OpenQClient.js
@@ -65,8 +65,10 @@ class OpenQClient {
 
 	async balanceOf(library, _callerAddress, _tokenAddress) {
 		const promise = new Promise(async (resolve, reject) => {
-			const signer = library.getSigner();
-
+			const signer = library?.getSigner();
+			if(!signer){
+				resolve({noSigner: true});
+			}
 			const contract = this.ERC20(_tokenAddress, signer);
 			try {
 				let volume;


### PR DESCRIPTION
Closes #179. Just centres the text and makes it white.
Closes #178,
Handles errors that were occurring when users tried to fund bounties without a wallet connected by setting an error modal that tells them to connect their wallet.
Fixes an issue where error modals were being automatically dismissed or, in the case of the mint bounty modal, showing in front of the previous modal.
Changes tweet text too:
"Check out this bounty for OpenQDev on OpenQ. You can claim it just by making a pull requesting that completes the issue! http://localhost:3000/bounty/0x5850d2800d262728e8bf27e4a22ee7f174c66b92 "
