### PR TITLE
Chris

### DIFF
--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -6,7 +6,6 @@ import BountyCard from './BountyCard';
 import Dropdown from '../Toggle/Dropdown';
 import SearchBar from '../Search/SearchBar';
 import MintBountyButton from '../MintBounty/MintBountyButton';
-import Skeleton from 'react-loading-skeleton';
 
 const BountyList = ({ bounties, loading, complete, getMoreData, getNewData }) => {
 	// Hooks
@@ -229,12 +228,7 @@ const BountyList = ({ bounties, loading, complete, getMoreData, getNewData }) =>
 				</div>
 			</div>
 			<div className="text-gray-300 font-mont pt-1 font-normal">
-				{process.env.NEXT_PUBLIC_DEPLOY_ENV === 'docker' ? !isProcessed || loading  ?
-					<Skeleton  baseColor="#333" borderRadius={'1rem'} height={'12px'} width={100}/>:
-					<>
-						{searchedBounties.length && searchedBounties.length}
-						{searchedBounties.length == 1 ? ' Bounty found' : ' Bounties found'}
-					</>: null}
+				
 			</div>
 			{ !isProcessed || loading?
 				<>

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -227,9 +227,6 @@ const BountyList = ({ bounties, loading, complete, getMoreData, getNewData }) =>
 					</div>
 				</div>
 			</div>
-			<div className="text-gray-300 font-mont pt-1 font-normal">
-				
-			</div>
 			{ !isProcessed || loading?
 				<>
 					<BountyCard loading={true} />

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -55,7 +55,7 @@ const BountyList = ({ bounties, loading, complete, getMoreData, getNewData }) =>
 			}, true);
 
 			const isUnclaimed = bounty.status === 'OPEN';
-			const isFunded = bounty.deposits.length>1;
+			const isFunded = bounty.deposits.length>0;
 			return (containsSearch&&containsTag&&(localShowUnfunded||isFunded)&&(localShowClaimed||isUnclaimed));
 		});
 		if(displayBounties.length===0&&!complete){

--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -161,8 +161,8 @@ const BountyList = ({ bounties, loading, complete, getMoreData, getNewData }) =>
 		if(node){
 
 			let options = {
-				rootMargin: '50px',
-				threshold: 1
+				rootMargin: '100px',
+				threshold: .1
 			};
 			const callback = (entries)=>{
 				if(entries[0].isIntersecting&&isProcessed&&!complete&&!loading){
@@ -178,7 +178,7 @@ const BountyList = ({ bounties, loading, complete, getMoreData, getNewData }) =>
 
 	// Render
 	return (
-		<div className="xl:col-start-2 justify-self-center space-y-3 xl:w-full xl:max-w-6xl">
+		<div className="xl:col-start-2 justify-self-center space-y-3 xl:w-full xl:max-w-6xl pb-8">
 			<div className="grid lg:grid-cols-[repeat(4,_1fr)] gap-6">
 				<div className="flex rounded-lg lg:col-span-3 col-span-4 justify-center">
 					{tagSearch==='Search' ?

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -5,7 +5,7 @@ import Link from 'next/link';
 // Custom
 import StoreContext from '../../store/Store/StoreContext';
 
-const BountyClosed = ({ bounty }) => {
+const BountyClosed = ({bounty, showTweetLink}) => {
 
 	// State
 	const [appState] = useContext(StoreContext);
@@ -22,7 +22,7 @@ const BountyClosed = ({ bounty }) => {
 
 		}
 	});
-	
+	const tweetText = 'Just claimed a developer bounty from on OpenQ for : ';
 	const url=`${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/tx/${bounty.claimedTransactionHash}`;
 	//Render
 	return (
@@ -30,7 +30,22 @@ const BountyClosed = ({ bounty }) => {
 			<div className="flex flex-col space-y-5">
 				<h2 className="flex text-3xl font-semibold text-white justify-center pt-16">Bounty Closed</h2>
 				<div className="bg-claimed-bounty-inside col-span-3 border border-claimed-bounty rounded-lg text-white p-4">
-					<p>Closer: {closer}</p>
+					<div className='flex justify-between w-full'>
+						<p>Closer: {closer}</p>
+						{showTweetLink && <Link
+							href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyAddress}`}
+
+						>
+							<a className="hover:scale-105 duration-100" target="_blank">
+								<div id={'bounty-link'} className="cursor-pointer flex justify-end">
+									<svg viewBox="0 0 128 128" width="24" height="24">
+										<path d="M40.254 127.637c48.305 0 74.719-48.957 74.719-91.403 0-1.39 0-2.777-.075-4.156 5.141-4.547 9.579-10.18 13.102-16.633-4.79 2.602-9.871 4.305-15.078 5.063 5.48-4.02 9.582-10.336 11.539-17.774-5.156 3.743-10.797 6.38-16.68 7.801-8.136-10.586-21.07-13.18-31.547-6.32-10.472 6.86-15.882 21.46-13.199 35.617C41.922 38.539 22.246 26.336 8.915 6.27 1.933 20.94 5.487 39.723 17.022 49.16c-4.148-.172-8.207-1.555-11.832-4.031v.41c0 15.273 8.786 28.438 21.02 31.492a21.596 21.596 0 01-11.863.543c3.437 13.094 13.297 22.07 24.535 22.328-9.305 8.918-20.793 13.75-32.617 13.72-2.094 0-4.188-.15-6.266-.446 12.008 9.433 25.98 14.441 40.254 14.422" fill="#ffffff">
+										</path>
+									</svg> 
+								</div>
+							</a>
+						</Link>}
+					</div>
 					<p>Closing Transaction: <Link href={url}>
 						<span className="cursor-pointer break-words">
 							<span className="underline">{url}</span> 
@@ -38,7 +53,9 @@ const BountyClosed = ({ bounty }) => {
 							</svg>
 						</span>
 					</Link>
+					
 					</p>
+					<p className="text-right w-full">{}	</p>
 				</div>
 			</div>
 		</div>

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -25,6 +25,7 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 	const [transactionHash, setTransactionHash] = useState(null);
 	const [claimState, setClaimState] = useState(CONFIRM_CLAIM);
 	const [showClaimLoadingModal, setShowClaimLoadingModal] = useState(false);
+	const [justClaimed, setJustClaimed] = useState(false);
 	const canvas = useRef();
 
 	const claimed = bounty.status == 'CLOSED';
@@ -61,6 +62,7 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 				setClaimState(TRANSACTION_SUBMITTED);
 				await library.waitForTransaction(txnHash);
 				setClaimState(TRANSACTION_CONFIRMED);
+				setJustClaimed(true);
 				refreshBounty();
 				setClaimState(CONFIRM_CLAIM);
 				
@@ -87,7 +89,7 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 
 	if (claimed) {
 		return (
-			<BountyClosed bounty={bounty} />
+			<BountyClosed bounty={bounty} showTweetLink={justClaimed} />
 		);
 	} else {
 		return (

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -38,7 +38,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
 	const [token, setToken] = useState(appState.tokens[0]);
 
 	const claimed = bounty.status == 'CLOSED';
-	const loadingClosedOrZero = approveTransferState == CONFIRM || approveTransferState == APPROVING || approveTransferState == TRANSFERRING || claimed || parseFloat(volume) == 0 || volume == '';
+	const loadingClosedOrZero = approveTransferState == CONFIRM || approveTransferState == APPROVING || approveTransferState == TRANSFERRING || claimed || parseFloat(volume) == 0 || volume == '' || !account;
 	const disableOrEnable = `${loadingClosedOrZero ? 'confirm-btn-disabled cursor-not-allowed' : 'confirm-btn cursor-pointer'}`;
 	const fundButtonClasses = `flex flex-row justify-center space-x-5 items-center py-3 text-lg text-white ${disableOrEnable}`;
 
@@ -89,6 +89,8 @@ const FundPage = ({ bounty, refreshBounty }) => {
 		try {
 			setShowApproveTransferModal(true);
 			if (token.address != ethers.constants.AddressZero) {
+				setButtonText('Approving');
+				setApproveTransferState(APPROVING);
 				await appState.openQClient.approve(
 					library,
 					bounty.bountyAddress,
@@ -165,7 +167,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
 
 					<div className="flex w-full flex-row justify-between items-center px-4 py-3 rounded-lg py-1 bg-dark-mode border border-web-gray text-white">
 						<div className='text-white flex items-center gap-3 w-full'>
-							<ToolTip customOffsets={[370, 100]} styles="w-96" toolTipText={'This is the number of days that your deposit will be in escrow. After this many days, you\'re deposit will be fully refundable if the bounty has still not been claimed.'} >
+							<ToolTip customOffsets={[380, 120]} styles="w-96" toolTipText={'This is the number of days that your deposit will be in escrow. After this many days, you\'re deposit will be fully refundable if the bounty has still not been claimed.'} >
 								<div className='cursor-help rounded-full border-2 border-web-gray aspect-square leading-6 h-6 box-content text-center font-bold text-web-gray'>?</div>
 							</ToolTip>
 							<span>Deposit Locked Period</span>
@@ -183,31 +185,33 @@ const FundPage = ({ bounty, refreshBounty }) => {
 					</div>
 
 					<div>
-						<button
-							className={fundButtonClasses}
-							disabled={loadingClosedOrZero}
-							type="button"
-							onClick={() => {
-								setConfirmationMessage(
-									`You are about to fund this bounty at address ${bounty.bountyAddress.substring(
-										0,
-										12
-									)}...${bounty.bountyAddress.substring(32)} with ${volume} ${token.name
-									}.
+						<ToolTip hideToolTip={account} toolTipText={'Connect your wallet to fund this bounty!'} customOffsets={[0,0]}>
+							<button
+								className={fundButtonClasses}
+								disabled={loadingClosedOrZero}
+								type="button"
+								onClick={() => {
+									setConfirmationMessage(
+										`You are about to fund this bounty at address ${bounty.bountyAddress.substring(
+											0,
+											12
+										)}...${bounty.bountyAddress.substring(32)} with ${volume} ${token.name
+										}.
 									
 									This will be refundable after ${depositPeriodDays} ${depositPeriodDays == 1 ? 'day' : 'days'}.
 									
 									Is this correct?`
-								);
-								setApproveTransferState(CONFIRM);
-								setShowApproveTransferModal(true);
-							}}
-						>
-							<div>{buttonText}</div>
-							<div>{approveTransferState != RESTING && approveTransferState != SUCCESS && approveTransferState != ERROR ? (
-								<ButtonLoadingIcon />
-							) : null}</div>
-						</button>
+									);
+									setApproveTransferState(CONFIRM);
+									setShowApproveTransferModal(true);
+								}}
+							>
+								<div>{buttonText}</div>
+								<div>{approveTransferState != RESTING && approveTransferState != SUCCESS && approveTransferState != ERROR ? (
+									<ButtonLoadingIcon />
+								) : null}</div>
+							</button>
+						</ToolTip>
 					</div>
 				</div>
 

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -14,9 +14,9 @@ const Layout = ({ children }) => {
 	const [showBanner, updateShowBanner] = useState(true);
 	return (
 		<div>{showBanner && isFirstLaunch ?
-			<div className="w-full bg-inactive-accent-inside border-inactive-accent border-b h-12 text-white grid grid-cols-wide content-center px-4">
+			<div className="w-full bg-inactive-accent-inside border-inactive-accent border-b text-white grid grid-cols-wide content-center py-4 items-center px-4">
 
-				<div className='col-start-2 col-end-3 text-center'>Welcome to <span className='font-bold text-tinted'>OpenQ!</span> Since it{'\''}s your first time with us, check out our <a className='underline font-bold text-tinted' href="https://vimeo.com/677467068" target="_blank" rel="noreferrer">demo</a>.</div>
+				<div className='col-start-2 col-end-3 text-center min-w-[300px]'>Welcome to <span className='font-bold text-tinted'>OpenQ!</span> Since it{'\''}s your first time with us, check out our <a className='underline font-bold text-tinted' href="https://vimeo.com/677467068" target="_blank" rel="noreferrer">demo</a>.</div>
 				<button onClick={() => updateShowBanner(false)} className='w-6  h-6 justify-self-end text-white cursor-pointer font-bold bg-inactive-accent hover:bg-active-accent rounded-md text-center'>{'\×'}</button>
 			</div> : null}
 		<div className="flex flex-row">

--- a/components/Layout/ProfilePicture.js
+++ b/components/Layout/ProfilePicture.js
@@ -3,17 +3,14 @@ import React, { useEffect, useState, useContext } from 'react';
 import Image from 'next/image';
 // Custom
 import AuthContext from '../../store/AuthStore/AuthContext';
-import StoreContext from '../../store/Store/StoreContext';
 
 const ProfilePicture = () => {
 	const [authState] = useContext(AuthContext);
-	const [appState] = useContext(StoreContext);
 
 	const [propicUrl, setProPicUrl] = useState(null);
 
 	useEffect(() => {
 		async function setProfilePicture() {
-			const isAuthenticated = authState.isAuthenticated;
 			const avatarUrl = authState.avatarUrl;
 			setProPicUrl(avatarUrl);
 		}

--- a/components/Organization/OrganizationHomepage.js
+++ b/components/Organization/OrganizationHomepage.js
@@ -74,7 +74,7 @@ const OrganizationHomepage = () => {
 						<UnexpectedError />
 						:
 						isLoading
-							? <><OrganizationCard /><OrganizationCard /></>
+							? <><OrganizationCard /><OrganizationCard /><OrganizationCard /><OrganizationCard /></>
 							: organizations
 								.filter((organization) => {
 									return organizationSearchTerm

--- a/components/Utils/ToolTip.js
+++ b/components/Utils/ToolTip.js
@@ -3,14 +3,15 @@
 import React, { useState } from 'react';
 
 const ToolTip = (props)=>{
-	const {toolTipText, customOffsets} = props;
+	const {toolTipText, customOffsets, hideToolTip} = props;
 	const [x, y] = customOffsets;
 	const [isToolTip, setIsTooltip] = useState();
 	const showToolTip = (e) =>{
 		setIsTooltip([e.pageX, e.pageY]);
 	};
+	if(hideToolTip)return props.children;
 	return (
-		<div className='text-white' onMouseEnter={showToolTip} onMouseLeave={()=>setIsTooltip(false)}>
+		<div className='text-white' onMouseMove={showToolTip} onMouseLeave={()=>setIsTooltip(false)}>
 			{props.children}	
 			{isToolTip&& <div 
 				style={{

--- a/pages/auth/github.js
+++ b/pages/auth/github.js
@@ -44,8 +44,9 @@ function GitHubAuth() {
 
 	return (
 		<div className='flex fixed inset-0 justify-center'>
-			<div className='text-white h-min self-center'>
-			Authenticating with GitHub. You will be redirected to the Claim page once we{'\''}re done.
+			<div className='text-white h-min self-center flex flex-col items-center gap-4'>
+				<p>Authenticating with GitHub. You will be redirected to the Claim page once we{'\''}re done.</p>
+				<svg xmlns="http://www.w3.org/2000/svg" className="animate-spin" viewBox="0 0 512 512" height="20" width="20" fill="#ffffff"><path d="M288 39.056v16.659c0 10.804 7.281 20.159 17.686 23.066C383.204 100.434 440 171.518 440 256c0 101.689-82.295 184-184 184-101.689 0-184-82.295-184-184 0-84.47 56.786-155.564 134.312-177.219C216.719 75.874 224 66.517 224 55.712V39.064c0-15.709-14.834-27.153-30.046-23.234C86.603 43.482 7.394 141.206 8.003 257.332c.72 137.052 111.477 246.956 248.531 246.667C393.255 503.711 504 392.788 504 256c0-115.633-79.14-212.779-186.211-240.236C302.678 11.889 288 23.456 288 39.056z"/></svg>
 			</div>
 		</div>
 	);

--- a/pages/bounty/[address].js
+++ b/pages/bounty/[address].js
@@ -79,8 +79,8 @@ const address = () => {
 		if (address) {
 			const route = sessionStorage.getItem(address);
 		
-			if(route&&route!==internalMenu){
-				setInternalMenu(route);
+			if(route!==internalMenu){
+				setInternalMenu(route || 'View');
 			}
 			setRedirectUrl(`${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${address}`);
 			populateBountyData();
@@ -115,11 +115,13 @@ const address = () => {
 	}
 	else return (
 		<div className="flex flex-col font-mont justify-center items-center pt-7">
-			<Toggle toggleFunc={handleToggle} toggleVal={internalMenu||'View'} names={['View', 'Fund', 'Refund', 'Claim']}/>
-			{internalMenu == 'Fund' && bounty  ? <FundPage bounty={bounty} refreshBounty={refreshBounty} /> : 
-				internalMenu == 'Claim' && bounty ? <ClaimPage bounty={bounty} refreshBounty={refreshBounty} /> : 
-					internalMenu == 'Refund' && bounty ? (<RefundPage bounty={bounty} refreshBounty={refreshBounty} />) : 
-						<BountyCardDetails bounty={bounty} tokenValues={tokenValues} />}
+			<Toggle toggleFunc={handleToggle} toggleVal={internalMenu} names={['View', 'Fund', 'Refund', 'Claim']}/>
+			{internalMenu == 'View' ? (
+				<BountyCardDetails bounty={bounty} tokenValues={tokenValues} />
+			) : null}
+			{internalMenu == 'Fund' && bounty  ? <FundPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
+			{internalMenu == 'Claim' && bounty ? <ClaimPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
+			{internalMenu == 'Refund' && bounty ? (<RefundPage bounty={bounty} refreshBounty={refreshBounty} />) : null}
 			<canvas className="absolute inset-0 pointer-events-none" ref={canvas}></canvas>
 		</div>
 	);

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,7 +8,7 @@ import OrganizationHomepage from '../components/Organization/OrganizationHomepag
 
 export default function Index() {
 	const [internalMenu, setInternalMenu] = useState('org');
-	const batch = 3;
+	const batch = 10;
 	// State
 	const [bounties, setBounties] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);

--- a/pages/organization/[organization].js
+++ b/pages/organization/[organization].js
@@ -15,7 +15,7 @@ const organization = () => {
 	const [appState] = useContext(StoreContext);
 	const router = useRouter();
 
-	const batch=3;
+	const batch=10;
 	// State
 	const { organization } = router.query;
 	const [isLoading, setIsLoading] = useState(true);

--- a/services/github/GithubRepository.js
+++ b/services/github/GithubRepository.js
@@ -1,5 +1,5 @@
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
-import { GET_ORG_BY_ID, GET_ORG_BY_NAME, GET_ISSUE, GET_CURRENT_USER_AVATAR_URL, GET_ISSUE_BY_ID, GET_ISSUES_BY_ID, GET_ORGS_BY_ISSUES, GET_ISSUE_CLOSER } from './graphql/query';
+import { GET_ORG_BY_ID, GET_ORG_BY_NAME, GET_ISSUE, GET_ISSUE_BY_ID, GET_ISSUES_BY_ID, GET_ORGS_BY_ISSUES, GET_ISSUE_CLOSER } from './graphql/query';
 import fetch from 'cross-fetch';
 import { setContext } from '@apollo/client/link/context';
 

--- a/store/AuthStore/AuthReducer.js
+++ b/store/AuthStore/AuthReducer.js
@@ -1,19 +1,19 @@
 const AuthReducer = (state, action) => {
 	switch (action.type) {
-		case 'UPDATE_IS_AUTHENTICATED':
-			return {
-				...state,
-				isAuthenticated: action.payload.isAuthenticated,
-				avatarUrl: action.payload.avatarUrl,
-			};
-		case 'LOGOUT':
-			return {
-				...state,
-				isAuthenticated: action.payload,
-				avatarUrl: null,
-			};
-		default:
-			return state;
+	case 'UPDATE_IS_AUTHENTICATED':
+		return {
+			...state,
+			isAuthenticated: action.payload.isAuthenticated,
+			avatarUrl: action.payload.avatarUrl,
+		};
+	case 'LOGOUT':
+		return {
+			...state,
+			isAuthenticated: action.payload,
+			avatarUrl: null,
+		};
+	default:
+		return state;
 	}
 };
 


### PR DESCRIPTION
Closes #181 Now that I'd fixed the modals behaviour when the outside is clicked this just entailed putting back the lines that set approving state.
Closes #182 Checks for account existing when deciding whether to disable button. Also, if account doesn't exist this adds a tool tip with relevant text.
Closes #183 by adding this spinner
![image](https://user-images.githubusercontent.com/72156679/161285230-58390efe-61ff-4765-be96-41264340f32c.png)
Also removes flash of BountyDetailsPage skeleton when reloading the claim page and meaningless bounty count in BountyList.
Added a couple more org skeletons, now at least we start with a full row.
Switched pagination to batches of 10.
Closes #185 by adding this 
![image](https://user-images.githubusercontent.com/72156679/161325951-6c438a73-b357-4459-9242-24ea9f083abb.png)
Maybe we should have something more interesting for twitter.

