### PR TITLE
Chris

### DIFF
--- a/components/Authentication/AuthButton.js
+++ b/components/Authentication/AuthButton.js
@@ -5,12 +5,12 @@ import AuthContext from '../../store/AuthStore/AuthContext';
 import SignOut from './SignOut';
 import SignIn from './SignIn';
 
-const AuthButton = ({ redirectUrl }) => {
+const AuthButton = ({ redirectUrl, propicUrl, styles }) => {
 	const [authState,] = useContext(AuthContext);
 
 	return (
 		<>
-			{authState.isAuthenticated ? <SignOut /> : <SignIn redirectUrl={redirectUrl} />}
+			{authState.isAuthenticated ? <SignOut propicUrl={propicUrl} styles={styles} /> : <SignIn redirectUrl={redirectUrl} styles={styles} />}
 		</>
 	);
 };

--- a/components/Authentication/SignIn.js
+++ b/components/Authentication/SignIn.js
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 // Custom
 import Image from 'next/image';
 
-const SignIn = ({ redirectUrl }) => {
+const SignIn = ({ redirectUrl, styles }) => {
 	const router = useRouter();
 
 	const signIn = () => {
@@ -32,17 +32,15 @@ const SignIn = ({ redirectUrl }) => {
 	return (
 		<button
 			onClick={() => signIn()}
-			className="col-span-3 pb-1 space-x-2 font-mont rounded-lg border border-web-gray py-2 px-3 text-white font-bold cursor-pointer hover:border-white"
+			className={`col-span-3 font-mont rounded-lg border border-web-gray py-2 px-3 text-white font-bold cursor-pointer hover:border-white ${styles}`}
 		>
-			<div className="flex flex-row justify-center space-x-3">
-				<div>
-					<Image
-						src="/BountyMaterial/github-white.png"
-						alt="Picture of the author"
-						width={20}
-						height={20}
-					/>
-				</div>
+			<div className="flex flex-row items-center justify-center space-x-3">
+				<Image
+					src="/BountyMaterial/github-white.png"
+					alt="Picture of the author"
+					width={20}
+					height={20}
+				/>
 				<div>Sign In</div>
 			</div>
 		</button>

--- a/components/Authentication/SignOut.js
+++ b/components/Authentication/SignOut.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import AuthContext from '../../store/AuthStore/AuthContext';
 import Image from 'next/image';
 
-const SignOut = () => {
+const SignOut = ({propicUrl, styles}) => {
 	const [, setAuthState] = useContext(AuthContext);
 
 	const signOut = () => {
@@ -27,17 +27,16 @@ const SignOut = () => {
 	return (
 		<button
 			onClick={() => signOut()}
-			className="col-span-3 pb-1 space-x-2 font-mont rounded-lg border border-web-gray py-2 px-3 text-white font-bold cursor-pointer hover:border-white"
+			className={`col-span-3 font-mont py-2 rounded-lg border border-web-gray px-3 text-white font-bold cursor-pointer hover:border-white ${styles}`}
 		>
-			<div className="flex flex-row justify-center space-x-3">
-				<div>
-					<Image
-						src="/BountyMaterial/github-white.png"
-						alt="Picture of the author"
-						width={20}
-						height={20}
-					/>
-				</div>
+			<div className="flex flex-row justify-center items-center space-x-3">
+				<Image
+					src={propicUrl||'/BountyMaterial/github-white.png'}
+					alt="Picture of the author"
+					width={24}
+					height={24}
+					className={'rounded-full'}
+				/>
 				<div>Sign Out</div>
 			</div>
 		</button>

--- a/components/Bounty/BountyCard.js
+++ b/components/Bounty/BountyCard.js
@@ -109,18 +109,18 @@ const BountyCard = ({ bounty, loading }) => {
 				<div className="flex flex-row pt-3 pl-6 pr-3  items-center justify-between xs:pb-5 pb-5 md:pb-0">
 					<div>
 						{bounty?.labels ? (
-							<div className="flex flex-row justify-between gap-2">
+							<div className="flex flex-row flex-wrap justify-between gap-2">
 								{bounty?.labels.map((label, index) => {
 									if (index < 2) {
 										return (
 											<div
 												key={index}
 												style={{
-													borderColor: label.color,
+													borderColor: `#${label.color}`,
 													opacity: .9,
-													color: label.color,
+													color: `#${label.color}`,
 												}}
-												className="font-mont rounded-lg text-xs py-1 px-2 font-bold border text-white"
+												className="font-mont rounded-lg text-xs py-1 px-2 font-bold border text-white truncate"
 											>
 												{label.name}
 											</div>

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -32,12 +32,29 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 				<LabelsList bounty={bounty} />
 				{bounty?
 					bounty.bountyTokenBalances.length != 0 ? (
-						<TokenBalances
-							header={bounty?.status == 'CLOSED' ? 'Total Value Claimed' : 'Current Total Value Locked'}
-							tokenBalances={bounty?.bountyTokenBalances}
-							tokenValues={tokenValues}
-							singleCurrency={false}
-						/>
+						<>
+							<div className="text-white flex font-bold gap-4 text-lg">
+								{bounty?.status == 'CLOSED' ? 
+									<>
+										<span>Total Value Claimed</span>
+										<svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+											<path strokeLinecap="round" strokeLinejoin="round" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
+										</svg>
+									</> :
+									<>
+										<span>Current Total Value Locked</span>
+										<svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+											<path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+										</svg>
+									</>
+								}
+							</div>
+							<TokenBalances
+								tokenBalances={bounty?.bountyTokenBalances}
+								tokenValues={tokenValues}
+								singleCurrency={false}
+							/>
+						</>
 					) : (
 						<div className="pt-5 pb-5 font-semibold text-white">No deposits</div>
 					) :

--- a/components/Bounty/BountyCardDetailsModal.js
+++ b/components/Bounty/BountyCardDetailsModal.js
@@ -28,12 +28,12 @@ const BountyCardDetailsModal = ({ bounty, TVL, closeModal, tokenValues}) => {
 	}, [modal]);
 
 	return (
-		<div className='flex justify-center items-center bg-overlay inset-0 z-20 fixed text-white py-4 overflow-hidden z-30'>
+		<div className='flex justify-center items-center bg-overlay inset-0 fixed text-white py-4 overflow-hidden z-30'>
 			<div ref={modal} className="bg-dark-mode w-5/6 h-min rounded-lg lg:w-2/3 max-w-3xl text-lg relative overflow-hidden">
-				<div className="px-8 pt-4">
+				<div className="px-8 py-4">
 					<BountyCardHeader bounty={bounty} />
 				</div>					
-				<div className="px-8 py-4 max-h-[80vh] overflow-y-auto">
+				<div className="px-8 py-4 max-h-[60vh] overflow-y-auto">
 					<div className="text-base">
 						<BountyStatus bounty={bounty} />
 					</div>

--- a/components/Bounty/LabelsList.js
+++ b/components/Bounty/LabelsList.js
@@ -5,19 +5,21 @@ import Skeleton from 'react-loading-skeleton';
 // Custom
 
 const LabelsList = ({ bounty }) => {
+	
 	return (
 		<div className="flex flex-row pt-3 space-x-2">
-			<div className="space-x-2">
+			<div className="space-x-2 space-y-2">
 				{bounty?.labels.map((label, index) => {
+					console.log(label);
 					return (
 						<button
 							key={index}
+							className="rounded-lg text-xs py-1 px-2 font-bold border border-purple-500 text-white truncate"
 							style={{
-								borderColor: label.color,
+								borderColor: `#${label.color}`,
 								opacity: .9,
-								color: label.color,
+								color: `#${label.color}`,
 							}}
-							className="rounded-lg text-xs py-1 px-2 font-bold border border-purple-500 text-white"
 						>
 							{label.name}
 						</button>

--- a/components/Bounty/LabelsList.js
+++ b/components/Bounty/LabelsList.js
@@ -5,12 +5,10 @@ import Skeleton from 'react-loading-skeleton';
 // Custom
 
 const LabelsList = ({ bounty }) => {
-	
 	return (
 		<div className="flex flex-row pt-3 space-x-2">
 			<div className="space-x-2 space-y-2">
 				{bounty?.labels.map((label, index) => {
-					console.log(label);
 					return (
 						<button
 							key={index}

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -5,7 +5,7 @@ import Link from 'next/link';
 // Custom
 import StoreContext from '../../store/Store/StoreContext';
 
-const BountyClosed = ({bounty, showTweetLink}) => {
+const BountyClosed = ({bounty}) => {
 
 	// State
 	const [appState] = useContext(StoreContext);
@@ -32,11 +32,11 @@ const BountyClosed = ({bounty, showTweetLink}) => {
 				<div className="bg-claimed-bounty-inside col-span-3 border border-claimed-bounty rounded-lg text-white p-4">
 					<div className='flex justify-between w-full'>
 						<p>Closer: {closer}</p>
-						{showTweetLink && <Link
+						{true && <Link
 							href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyAddress}`}
 
 						>
-							<a className="hover:scale-105 duration-100" target="_blank">
+							<a className="hover:scale-105 animate-single-bounce duration-100" target="_blank">
 								<div id={'bounty-link'} className="cursor-pointer flex justify-end">
 									<svg viewBox="0 0 128 128" width="24" height="24">
 										<path d="M40.254 127.637c48.305 0 74.719-48.957 74.719-91.403 0-1.39 0-2.777-.075-4.156 5.141-4.547 9.579-10.18 13.102-16.633-4.79 2.602-9.871 4.305-15.078 5.063 5.48-4.02 9.582-10.336 11.539-17.774-5.156 3.743-10.797 6.38-16.68 7.801-8.136-10.586-21.07-13.18-31.547-6.32-10.472 6.86-15.882 21.46-13.199 35.617C41.922 38.539 22.246 26.336 8.915 6.27 1.933 20.94 5.487 39.723 17.022 49.16c-4.148-.172-8.207-1.555-11.832-4.031v.41c0 15.273 8.786 28.438 21.02 31.492a21.596 21.596 0 01-11.863.543c3.437 13.094 13.297 22.07 24.535 22.328-9.305 8.918-20.793 13.75-32.617 13.72-2.094 0-4.188-.15-6.266-.446 12.008 9.433 25.98 14.441 40.254 14.422" fill="#ffffff">

--- a/components/Claim/ClaimLoadingModal.js
+++ b/components/Claim/ClaimLoadingModal.js
@@ -66,7 +66,7 @@ const ClaimLoadingModal = ({ confirmMethod, url, ensName, account, claimState, a
 							</div>
 						</div>
 						<div className="flex-auto">
-							<p className="text-md text-white pb-12 text-center">
+							<p className="text-md text-white pb-12 text-center break-words">
 								{message[claimState]}
 							</p>
 						</div>

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -140,7 +140,10 @@ const FundPage = ({ bounty, refreshBounty }) => {
 	}
 
 	function onVolumeChange(volume) {
-		if(0 < parseFloat(volume) && parseFloat(volume) < 1000) setVolume(parseFloat(volume));
+		if(!volume.includes('.')){
+			volume = parseInt(volume)||0;
+		}
+		if(0 <= parseInt(volume) && parseInt(volume*100) < 100000) setVolume(volume);
 		if(volume===''){setVolume(0);}
 	}
 	const onDepositPeriodChanged = (e) =>{

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -32,7 +32,7 @@ const Layout = ({ children }) => {
 						<div className="pr-5">
 							<ConnectButton />
 						</div>
-						<div className="w-8">
+						<div>
 							<ProfilePicture />
 						</div>
 					</div>

--- a/components/Layout/MobileSidebar.js
+++ b/components/Layout/MobileSidebar.js
@@ -23,9 +23,7 @@ const MobileSidebar = () => {
 
 			<div className="flex flex-row space-x-4 items-center">
 				<MobileConnectButton />
-				<div className="w-8 h-8">
-					<ProfilePicture />
-				</div>
+				<ProfilePicture mobile={true} />
 			</div>
 		</div>
 	);

--- a/components/Layout/ProfilePicture.js
+++ b/components/Layout/ProfilePicture.js
@@ -1,34 +1,54 @@
 // Third Party
 import React, { useEffect, useState, useContext } from 'react';
 import Image from 'next/image';
+import {useRouter} from 'next/router';
 // Custom
 import AuthContext from '../../store/AuthStore/AuthContext';
+import AuthButton from '../../components/Authentication/AuthButton';
 
-const ProfilePicture = () => {
+const ProfilePicture = ({mobile}) => {
+
+	// Context
 	const [authState] = useContext(AuthContext);
+	const router = useRouter();
 
+	// State
 	const [propicUrl, setProPicUrl] = useState(null);
+	const [showModal, setShowModal] = useState(!authState.isAuthenticated);
 
+	// Effects
 	useEffect(() => {
 		async function setProfilePicture() {
 			const avatarUrl = authState.avatarUrl;
 			setProPicUrl(avatarUrl);
 		}
 		setProfilePicture();
+		if(authState.isAuthenticated){
+			setShowModal(false);
+		}
 	}, [authState]);
 
 	return (
-		<>
-			{propicUrl != null ? (
-				<Image
-					src={propicUrl}
-					width={180}
-					height={180}
-					alt={'propic'}
-					className="rounded-full"
-				/>
-			) : null}
-		</>
+		<div className='flex items-center h-12 content-center'>		
+			{showModal|| !authState.isAuthenticated ? 
+				<div className={`flex bg-inactive-gray border-web-gray hover:border-white border ${mobile ? 'h-10' : 'h-12'} rounded-lg w-max`}>
+					<AuthButton redirectUrl={process.env.NEXT_PUBLIC_BASE_URL + router.asPath} propicUrl={propicUrl} styles="border-none"/>
+					{authState.isAuthenticated && <button onClick={()=>setShowModal(false)} className='text-tinted hover:text-white pr-2 font-bold relative -top-0.5'>×</button>}
+				</div>:
+				<button className='flex items-center' onClick={()=>setShowModal(true)}>
+					{propicUrl != null ? (
+						<Image
+							src={propicUrl}
+							width={mobile ? 32 : 46}
+							height={mobile ? 32 : 46}
+							alt={'profile pic'}
+							className="rounded-full"
+					
+						/>
+					) : null}
+				</button>
+			}
+		</div>
 	);
 };
 

--- a/components/MintBounty/BountyAlreadyMintedMessage.js
+++ b/components/MintBounty/BountyAlreadyMintedMessage.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Link from 'next/link';
 
-export default function BountyAlreadyMintedMessage({ bountyAddress }) {
+export default function BountyAlreadyMintedMessage({ bountyAddress, claimed }) {
 	return (
 		<div className="flex flex-row items-center space-x-1">
-			<div className="pt-4 text-white">Bounty is already minted, view</div>
+			<div className="pt-4 text-white">Bounty is already {claimed? 'claimed': 'minted'}, view</div>
 			<Link
 				href={`/?address=${bountyAddress}}`}
 				as={`/bounty/${bountyAddress}`}

--- a/components/MintBounty/IssueDetailsBubble.js
+++ b/components/MintBounty/IssueDetailsBubble.js
@@ -11,7 +11,7 @@ export default function IssueDetailsBubble({ issueData }) {
 					<div className="">
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
-							fill="#15FB31"
+							fill={ issueData?.closed ? '#F0431D' : '#15FB31' }
 							viewBox="0 0 16 16"
 							width="17"
 							height="17"

--- a/components/MintBounty/States.js
+++ b/components/MintBounty/States.js
@@ -69,6 +69,7 @@ export const BOUNTY_EXISTS = (bounty) => {
 		bounty: bounty,
 		bountyAddress: bounty.bountyAddress,
 		bountyExists: true,
+		claimed: bounty.status === 'CLOSED'
 	};
 };
 

--- a/components/Utils/ToolTip.js
+++ b/components/Utils/ToolTip.js
@@ -11,9 +11,9 @@ const ToolTip = (props)=>{
 	};
 	if(hideToolTip)return props.children;
 	return (
-		<div className='text-white' onMouseMove={showToolTip} onMouseLeave={()=>setIsTooltip(false)}>
+		<div className={`text-white ${props.outerStyles}`} onMouseMove={showToolTip} onMouseLeave={()=>setIsTooltip(false)}>
 			{props.children}	
-			{isToolTip&& <div 
+			{isToolTip&& <div
 				style={{
 					position: 'fixed',
 					left: (isToolTip[0]-x)>5 ? isToolTip[0]-x : 5,

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -79,9 +79,9 @@ const ConnectButton = () => {
 				<button
 					ref= {buttonRef}
 					onClick={()=>{setShowModal(!showModal);}}
-					className="group flex gap-x-3 font-mont whitespace-nowrap rounded-lg border border-inactive-accent bg-inactive-accent-inside py-2 px-6 text-white font-semibold cursor-pointer hover:border-active-accent"
+					className="group flex items-center gap-x-3 h-12 font-mont whitespace-nowrap rounded-lg border border-inactive-accent bg-inactive-accent-inside py-2 px-6 text-white font-semibold cursor-pointer hover:border-active-accent"
 				>
-					<span className="border-2 border-inactive-accent rounded-full leading-3 group-hover:border-active-accent" ref={iconWrapper}></span>
+					<span className="border-2 border-inactive-accent rounded-full h-7 group-hover:border-active-accent" ref={iconWrapper}></span>
 					<span className='py'>{ensName|| `${firstThree}...${lastThree}`}</span>
 				</button>
 				{showModal&&
@@ -99,7 +99,7 @@ const ConnectButton = () => {
 			<div>
 				<button
 					onClick={addOrSwitchNetwork}
-					className="font-mont whitespace-nowrap rounded-lg border border-inactive-accent bg-inactive-accent-inside py-2.5 px-6 text-white font-semibold cursor-pointer hover:border-active-accent"
+					className="flex items-center font-mont whitespace-nowrap h-12 rounded-lg border border-inactive-accent bg-inactive-accent-inside py-2.5 px-6 text-white font-semibold cursor-pointer hover:border-active-accent"
 				>
 					Use{' '}
 					{
@@ -116,7 +116,7 @@ const ConnectButton = () => {
 			<div>
 				<button
 					onClick={onClickConnect}
-					className="font-mont whitespace-nowrap rounded-lg border border-inactive-accent bg-inactive-accent-inside py-2.5 px-6 text-white font-semibold cursor-pointer hover:border-active-accent"
+					className="flex items-center font-mont whitespace-nowrap h-12 rounded-lg border border-inactive-accent bg-inactive-accent-inside py-2 px-6 text-white font-semibold cursor-pointer hover:border-active-accent"
 				>
 					{isConnecting? 'Connecting...': 'Connect Wallet'}
 				</button>

--- a/components/WalletConnect/MobileConnectButton.js
+++ b/components/WalletConnect/MobileConnectButton.js
@@ -104,32 +104,30 @@ const MobileConnectButton = () => {
 		);
 	} else {
 		return (
-			<div>
-				<button
-					className='text-white flex gap-2 text-xs border border-inactive-accent rounded-lg p-2 bg-dark-mode font-semibold'
-					onClick={onClickConnect}>
-					<span>{isConnecting? 'Connecting...': 'Connect '}</span>
-					<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg" className="mr-2">
-						<path d="M14 5.5V2.5C14 2.23478 13.8946 1.98043 13.7071 1.79289C13.5196 1.60536 13.2652 1.5 13 1.5H3C2.46957 1.5 1.96086 1.71071 1.58579 2.08579C1.21071 2.46086 1 2.96957 1 3.5M1 3.5C1 4.03043 1.21071 4.53914 1.58579 4.91421C1.96086 5.28929 2.46957 5.5 3 5.5H15C15.2652 5.5 15.5196 5.60536 15.7071 5.79289C15.8946 5.98043 16 6.23478 16 6.5V9.5M1 3.5V15.5C1 16.0304 1.21071 16.5391 1.58579 16.9142C1.96086 17.2893 2.46957 17.5 3 17.5H15C15.2652 17.5 15.5196 17.3946 15.7071 17.2071C15.8946 17.0196 16 16.7652 16 16.5V13.5" stroke="url(#wallet_gradient)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+			<button
+				className='text-white flex items-center gap-2 text-xs border border-inactive-accent h-10 rounded-lg p-2 bg-dark-mode font-semibold'
+				onClick={onClickConnect}>
+				<span className='font-bold'>{isConnecting? 'Connecting...': 'Connect '}</span>
+				<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg" className="mr-2">
+					<path d="M14 5.5V2.5C14 2.23478 13.8946 1.98043 13.7071 1.79289C13.5196 1.60536 13.2652 1.5 13 1.5H3C2.46957 1.5 1.96086 1.71071 1.58579 2.08579C1.21071 2.46086 1 2.96957 1 3.5M1 3.5C1 4.03043 1.21071 4.53914 1.58579 4.91421C1.96086 5.28929 2.46957 5.5 3 5.5H15C15.2652 5.5 15.5196 5.60536 15.7071 5.79289C15.8946 5.98043 16 6.23478 16 6.5V9.5M1 3.5V15.5C1 16.0304 1.21071 16.5391 1.58579 16.9142C1.96086 17.2893 2.46957 17.5 3 17.5H15C15.2652 17.5 15.5196 17.3946 15.7071 17.2071C15.8946 17.0196 16 16.7652 16 16.5V13.5" stroke="url(#wallet_gradient)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
 
-						</path>
-						<path d="M17 9.5V13.5H13C12.4696 13.5 11.9609 13.2893 11.5858 12.9142C11.2107 12.5391 11 12.0304 11 11.5C11 10.9696 11.2107 10.4609 11.5858 10.0858C11.9609 9.71071 12.4696 9.5 13 9.5H17Z" stroke="url(#wallet_gradient)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-						</path>
-						<defs>
-							<linearGradient id="wallet_gradient" x1="8.5" y1="-6.5" x2="-7.46674" y2="8.46881" gradientUnits="userSpaceOnUse">
-								<stop stopColor="#4633cc"></stop>
-								<stop offset="1" stopColor="#9e3166"></stop>
-							</linearGradient>
-							<linearGradient id="wallet_gradient" x1="14" y1="7.5" x2="10.3077" y2="13.0385" gradientUnits="userSpaceOnUse">
-								<stop stopColor="#9e3166"></stop>
-								<stop offset="1" stopColor="#9e3166"></stop>
-							</linearGradient>
-						</defs>
-					</svg>
+					</path>
+					<path d="M17 9.5V13.5H13C12.4696 13.5 11.9609 13.2893 11.5858 12.9142C11.2107 12.5391 11 12.0304 11 11.5C11 10.9696 11.2107 10.4609 11.5858 10.0858C11.9609 9.71071 12.4696 9.5 13 9.5H17Z" stroke="url(#wallet_gradient)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+					</path>
+					<defs>
+						<linearGradient id="wallet_gradient" x1="8.5" y1="-6.5" x2="-7.46674" y2="8.46881" gradientUnits="userSpaceOnUse">
+							<stop stopColor="#4633cc"></stop>
+							<stop offset="1" stopColor="#9e3166"></stop>
+						</linearGradient>
+						<linearGradient id="wallet_gradient" x1="14" y1="7.5" x2="10.3077" y2="13.0385" gradientUnits="userSpaceOnUse">
+							<stop stopColor="#9e3166"></stop>
+							<stop offset="1" stopColor="#9e3166"></stop>
+						</linearGradient>
+					</defs>
+				</svg>
 				
 
-				</button>
-			</div>
+			</button>
 		);
 	}
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,7 +15,7 @@ padding-top: 16px;}
   background-color:  #58585833;
   border-radius: 1rem;
   margin-top: 2.25rem;
-  overflow-x:scroll;
+  overflow-x: auto;
   padding: 1rem;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,6 +82,22 @@ module.exports = {
 		gridTemplateColumns: {
 			'wide': '1fr 2fr 1fr',
 			'annoying': 'repeat( auto-fit, 192px)',
+		},
+		keyframes: {
+			bump: {
+				'0%':{
+					transform: 'translate(0, 0)'
+				},
+				'50%':{
+					transform: 'translate(0, -.1rem)  scale(1.10)'
+				},
+			
+				'100%':{
+					transform: 'translate(0, 0) scale(1.10)',
+				},	}		
+		},
+		animation: {
+			'single-bounce': 'bump 1s ease-in-out forwards'
 		}
 	},
 	variants: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -94,10 +94,20 @@ module.exports = {
 			
 				'100%':{
 					transform: 'translate(0, 0) scale(1.10)',
-				},	}		
+				},	
+			},
+			spin: {
+				'0%': {
+					transform: 'rotate(0deg)'
+				},
+				'100%': {
+					transform: 'rotate(360deg)'
+				}
+			}	
 		},
 		animation: {
-			'single-bounce': 'bump 1s ease-in-out forwards'
+			'single-bounce': 'bump 1s ease-in-out forwards',
+			'spin':'spin 1s linear infinite'
 		}
 	},
 	variants: {


### PR DESCRIPTION
Closes #189 by adding this lock 
![image](https://user-images.githubusercontent.com/72156679/162051413-fe14ba26-2293-4511-8a9c-b752e6f80218.png)
Closes #190 by moving the refresh function to the updateModal function where it only executes if the transaction is closed.
Closes #191 by switching the message from Bounty is already minted to Bounty is already claimed on condition the bounty is claimed.
Closes #192 by switching the color.
![image](https://user-images.githubusercontent.com/72156679/162052132-6bac71c2-7ec1-45cc-a56a-eff949c4b9dc.png)
Closes #193 by switching the x overflow here to auto.
Closes #194 by modifying the Auth button and making it show up when the clicks on the github profile. If they aren't logged in the Auth button shows up with the sign in option.
Closes #195 Allows decimal numbers.
Closes #196 Disables fund, mint, and claim buttons when the user is not connected or is connected to the wrong network. Adds a suitable tooltip to tell the user what's wrong.
Closes #197 Moves the tooltip to top left of mouse as requested.
![image](https://user-images.githubusercontent.com/72156679/162053091-033f10cd-741e-4123-a4af-32e7529a7428.png)




