### PR TITLE
Chris

### DIFF
--- a/components/Bounty/BountyCard.js
+++ b/components/Bounty/BountyCard.js
@@ -95,7 +95,7 @@ const BountyCard = ({ bounty, loading }) => {
 						</div>
 					</div>
 					{bounty?.avatarUrl?
-						<div className="flex flex-col">
+						<div className="flex flex-col invisible sm:visible">
 							<Image
 								src={bounty?.avatarUrl}
 								alt="avatarUrl"

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -62,7 +62,7 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 						<TokenBalances />
 					</>
 				}
-				<div className='text-white font-bold pt-2'>Deposits</div>
+				{bounty?.bountyTokenBalances.length != 0 && <div className='text-white font-bold pt-2'>Deposits</div>}
 				<div className="flex gap-x-8 flex-wrap">
 					{bounty ? bounty.deposits
 						.filter((deposit) => {

--- a/components/Claim/ClaimLoadingModal.js
+++ b/components/Claim/ClaimLoadingModal.js
@@ -9,6 +9,7 @@ import {
 	TRANSACTION_CONFIRMED,
 	CONFIRM_CLAIM
 } from './ClaimStates';
+import LoadingIcon from '../Loading/ButtonLoadingIcon';
 
 const ClaimLoadingModal = ({ confirmMethod, url, ensName, account, claimState, address, transactionHash, setShowClaimLoadingModal, error }) => {
 
@@ -66,7 +67,7 @@ const ClaimLoadingModal = ({ confirmMethod, url, ensName, account, claimState, a
 							</div>
 						</div>
 						<div className="flex-auto">
-							<p className="text-md text-white pb-12 text-center break-words">
+							<p className="text-md text-white pb-4 text-center break-words">
 								{message[claimState]}
 							</p>
 						</div>
@@ -96,6 +97,10 @@ const ClaimLoadingModal = ({ confirmMethod, url, ensName, account, claimState, a
 								</div>
 							</div>
 						) : null}
+						
+						{claimState===CHECKING_WITHDRAWAL_ELIGIBILITY &&
+						<div className='self-center'><LoadingIcon bg="colored" /></div>
+						}
 					</div>
 				</div>
 			</div>

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -122,10 +122,10 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 								hideToolTip={account && isOnCorrectNetwork} 
 								toolTipText={
 									account && isOnCorrectNetwork ?
-										'Please indicate the volume you\'d like to fund with.':
+										'Please indicate the volume you\'d like to claim with.':
 										account ? 
-											'Please switch to the correct network to fund this bounty.' : 
-											'Connect your wallet to fund this bounty!' } 
+											'Please switch to the correct network to claim this bounty.' : 
+											'Connect your wallet to claim this bounty!' } 
 								customOffsets={[0, 50]}>
 								<button
 									type="submit"

--- a/components/FundBounty/ApproveTransferModal.js
+++ b/components/FundBounty/ApproveTransferModal.js
@@ -9,10 +9,10 @@ import {
 	SUCCESS,
 	ERROR
 } from './ApproveTransferState';
+import LoadingIcon from '../Loading/ButtonLoadingIcon';
 
 const ApproveTransferModal = ({
 	approveTransferState,
-	address,
 	transactionHash,
 	setShowApproveTransferModal,
 	resetState,
@@ -28,7 +28,6 @@ const ApproveTransferModal = ({
 		resetState();
 		setShowApproveTransferModal(false);
 	};
-
 
 	useEffect(() => {
 		// Courtesy of https://stackoverflow.com/questions/32553158/detect-click-outside-react-component
@@ -75,7 +74,7 @@ const ApproveTransferModal = ({
 							</div>
 						</div>
 						<div className="flex-auto">
-							<p className="text-md text-white pb-12 text-center break-words">
+							<p className="text-md text-white pb-4 text-center break-words">
 								{message[approveTransferState]}
 							</p>
 						</div>
@@ -103,6 +102,9 @@ const ApproveTransferModal = ({
 								</button>
 							</div>
 						) : null}
+						{(approveTransferState===TRANSFERRING || approveTransferState === APPROVING) &&
+						<div className='self-center'><LoadingIcon bg="colored" /></div>
+						}
 					</div>
 				</div>
 			</div>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -199,7 +199,7 @@ const MintBountyModal = ({ modalVisibility }) => {
 								</div>
 								{/* {error ? errorMessage : null} */}
 								{isValidUrl && !issueFound && isLoadingIssueData ? (
-									<div className="pl-10 pt-5">
+									<div className="pt-5 self-center">
 										<LoadingIcon bg={'white'} />
 									</div>
 								) : null}

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -220,7 +220,7 @@ const MintBountyModal = ({ modalVisibility }) => {
 								</div>
 
 								<ToolTip
-									hideToolTip={enableMint}
+									hideToolTip={enableMint || transactionPending}
 									toolTipText={
 										account && isOnCorrectNetwork ?
 											'Please choose an elgible issue.' :
@@ -231,7 +231,7 @@ const MintBountyModal = ({ modalVisibility }) => {
 									<div className ="flex items-center justify-center p-5 rounded-b w-full">
 										<MintBountyModalButton
 											mintBounty={mintBounty}
-											enableMint={enableMint}
+											enableMint={enableMint && isOnCorrectNetwork}
 											transactionPending={transactionPending}
 										/>
 									</div>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -225,8 +225,8 @@ const MintBountyModal = ({ modalVisibility }) => {
 										account && isOnCorrectNetwork ?
 											'Please choose an elgible issue.' :
 											account ?
-												'Please switch to the correct network to fund this bounty.' :
-												'Connect your wallet to fund this bounty!'}
+												'Please switch to the correct network to mint a bounty.' :
+												'Connect your wallet to mint a bounty!'}
 									customOffsets =	{[0, 70]}>
 									<div className ="flex items-center justify-center p-5 rounded-b w-full">
 										<MintBountyModalButton

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -34,7 +34,7 @@ const DepositCard = ({ deposit, refundBounty, status, isOnCorrectNetwork }) => {
 			<ToolTip
 				outerStyles="w-full flex self-center w-1/2"
 				hideToolTip={ isOnCorrectNetwork} 
-				toolTipText={'Please switch to the correct network to refund this bounty.' } 
+				toolTipText={'Please switch to the correct network to refund this deposit.' } 
 				customOffsets={[0, 46]}>
 				<button	onClick={() => refundBounty(deposit.id)}
 					disabled={!isOnCorrectNetwork}

--- a/components/TokenBalances/TokenBalances.js
+++ b/components/TokenBalances/TokenBalances.js
@@ -54,14 +54,16 @@ const TokenBalances = ({ tokenBalances, tokenValues, header, singleCurrency, sho
 		<div className="flex flex-col">
 			<div className="font-semibold text-white">{header}</div>
 			<div className="font-bold text-xl text-white">
-				{tokenBalances?.length > 1 && !showOne
+				{tokenBalances && !showOne
 					? tokenValues
-						? `${appState.utils.formatter.format(tokenValues.total)}`
-						: <Skeleton width={'6rem'} height={'20px'}/> : null}
+						? `${appState.utils.formatter.format(tokenValues.total)}`:
+						tokenBalances.length===0 
+							? `${appState.utils.formatter.format(0)}`
+							: <Skeleton width={'6rem'} height={'20px'}/> : null}
 			</div>
 			<div className="flex flex-row space-x-2 pt-1">
 				<div>
-					{tokenValues && tokenBalances&&(displayedBalances.length > 0)
+					{tokenBalances&&((tokenValues && displayedBalances.length > 0) || tokenBalances.length===0)
 						? displayedBalances.map((tokenBalance) => {
 							const {symbol, tokenAddress, usdValue, formattedVolume} = tokenBalance;
 

--- a/pages/bounty/[address].js
+++ b/pages/bounty/[address].js
@@ -40,12 +40,11 @@ const address = () => {
 
 		try{
 		// or is it null?
-			while (bounty === undefined) {
+			while (!bounty) {
 				bounty = await appState.openQSubgraphClient.getBounty(address);
 				await sleep(500);
 			}
-
-			const issueData = await appState.githubRepository.fetchIssueById(bounty.bountyId);
+			const issueData = await appState.githubRepository.fetchIssueById(bounty?.bountyId);
 
 			const mergedBounty = { ...bounty, ...issueData };
 


### PR DESCRIPTION
Closes #212  was just a matter of adding the network bool to the button disabler.
Closes #211 ( I believe Andrew already did on his latest commits.)
Closes #210 by hiding tooltip when user is in the process of minting the bounty.
Closes #209. Also center's loading icon in Mint Bounty Modal for github issue data.
![image](https://user-images.githubusercontent.com/72156679/162435522-5bdbd44f-825a-4257-b881-12309ea39d86.png)

Also:
Fixes an issue where orgs with no deposits would display a skeleton on their about page for TVL.
Hides org avatar on BountyCard at small widths (it was covering content).  
Hides deposits heading in BountyDetails when there are no deposits.
