### PR TITLE
Chris

### DIFF
--- a/components/Bounty/BountyCard.js
+++ b/components/Bounty/BountyCard.js
@@ -73,7 +73,7 @@ const BountyCard = ({ bounty, loading }) => {
 								{loading?
 									<Skeleton width={'100%'}/>:
 									
-									`Issue Opened: ${appState.utils.formatDate(bounty?.createdAt)}`}
+									`Issue Opened: ${appState.utils.formatDate(bounty?.createdAt, true)}`}
 							</div>
 						</div>
 						<div className="flex flex-row items-center space-x-4 pt-1 w-full">
@@ -81,7 +81,7 @@ const BountyCard = ({ bounty, loading }) => {
 									
 								{loading?
 									<Skeleton width={'100%'}/>:
-									`Bounty Minted: ${appState.utils.formatUnixDate(parseInt(bounty?.bountyMintTime))}`
+									`Bounty Minted: ${appState.utils.formatUnixDate(parseInt(bounty?.bountyMintTime), true)}`
 								}
 							</div>
 						</div>

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -16,14 +16,14 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 
 	return (
 		<div className="flex flex-col font-mont pl-5 pr-5 md:pl-16 md:pr-16 pt-10 pb-10 my-16 border-web-gray border rounded-lg w-5/6 max-w-6xl">
-			<div className="flex flex-col border-b border-solid rounded-t">
+			<div className="flex flex-col border-b pb-6 border-solid rounded-t">
 				<BountyCardHeader bounty={bounty} />
 				<div
-					className="grid lg:grid-cols-[repeat(2,_minmax(300px,_1fr))] justify-center justify-items-start pt-5 mx-auto lg:mx-5 gap-5">
-					<div className="col-span-2 lg:col-span-1 lg:w-96">
+					className="grid md:grid-cols-[repeat(2,_minmax(260px,_1fr))] justify-center justify-items-stretch pt-5 mx-auto md:mx-2 gap-4">
+					<div className="col-span-2 md:col-span-1 md:w-64">
 						<BountyStatus bounty={bounty} />
 					</div>
-					<div className="col-span-2 lg:col-start-2 lg:w-96">
+					<div className="col-span-2 md:col-start-2 md:w-68">
 						<CopyBountyAddress bounty={bounty} />
 					</div>
 					<div>
@@ -81,7 +81,7 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 				</div>
 			</div>
 
-			<div className="flex flex-col pt-5">
+			<div className="flex flex-col pt-6">
 				<div className="flex flex-row justify-between">
 					<div className="font-bold text-xl text-white">Description</div>
 					<BountyLinks bounty={bounty} hideBountyLink={true}/>

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -70,7 +70,7 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 						.sort((a, b) => {
 							return (parseInt(a.receiveTime) + parseInt(a.expiration)) - (parseInt(b.receiveTime) + parseInt(b.expiration));
 						})
-						.map((deposit, index) => 	<MiniDepositCard key={index} deposit={deposit} showLink={false}/>
+						.map((deposit, index) => 	<MiniDepositCard key={index} deposit={deposit} status={bounty.status} showLink={false}/>
 						):
 						<>
 							<MiniDepositCard deposit={false} showLink={false}/>

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -15,18 +15,20 @@ import MiniDepositCard from './MiniDepositCard';
 const BountyCardDetails = ({ bounty, tokenValues }) => {
 
 	return (
-		<div className="flex flex-col font-mont pl-5 pr-5 md:pl-16 md:pr-16 pt-10 pb-10 my-16 border-web-gray border rounded-lg w-5/6 max-w-6xl">
-			<div className="flex flex-col border-b pb-6 border-solid rounded-t">
-				<BountyCardHeader bounty={bounty} />
+		<div className="flex flex-col w-full font-mont sm:pl-5 sm:pr-5 md:px-10 pt-10 pb-10 my-16 border-web-gray sm:border rounded-lg w-5/6 max-w-6xl">
+			<div className="flex w-full flex-col border-b pb-6 border-solid justify-items-center items-center content-between rounded-t">
+				<	div className='self-start w-full'>
+					<BountyCardHeader bounty={bounty} />
+				</div>
 				<div
-					className="grid md:grid-cols-[repeat(2,_minmax(260px,_1fr))] justify-center justify-items-stretch pt-5 mx-auto md:mx-2 gap-4">
-					<div className="col-span-2 md:col-span-1 md:w-64">
+					className="grid w-full lg:grid-cols-[repeat(auto-fill,_minmax(max(102px,_100%/4-16px),_1fr))] xl:grid-cols-[repeat(auto-fill,_minmax(max(102px,_100%/6-32px),_1fr))] justify-center lg:justify-items-start pt-5 mx-auto md:mx-2 gap-4">
+					<div className="xl:col-span-3 lg:col-span-2">
 						<BountyStatus bounty={bounty} />
 					</div>
-					<div className="col-span-2 md:col-start-2 md:w-68">
+					<div className="lg:col-span-2  xl:col-span-3">
 						<CopyBountyAddress bounty={bounty} />
 					</div>
-					<div>
+					<div className='lg:col-span-3'>
 						{bounty?
 							bounty.bountyTokenBalances.length != 0 ? (
 								<>
@@ -60,9 +62,8 @@ const BountyCardDetails = ({ bounty, tokenValues }) => {
 							</>
 						}
 					</div>
-				</div>
-				{bounty?.bountyTokenBalances.length != 0 && <div className='text-white text-center font-bold text-xl py-4'>Deposits</div>}
-				<div className="grid gap-4 lg:grid-cols-[repeat(auto-fill,_minmax(300px,_1fr))] w-full justify-space-between justify-items-center">
+					{bounty?.bountyTokenBalances.length != 0 && <div className='text-white text-center font-bold text-xl py-4 col-start-1 md:col-end-3 lg:col-end-[-1] w-full'>Deposits</div>}
+			
 					{bounty ? bounty.deposits
 						.filter((deposit) => {
 							return deposit.refunded == false;

--- a/components/Bounty/BountyCardDetailsModal.js
+++ b/components/Bounty/BountyCardDetailsModal.js
@@ -53,12 +53,12 @@ const BountyCardDetailsModal = ({ bounty, TVL, closeModal, tokenValues}) => {
 						<div className="border border-web-gray px-4 pb-1 w-max rounded-md">
 							<TokenBalances tokenBalances={bounty.bountyTokenBalances} tokenValues={tokenValues} showOne={true}/>						
 						</div>
-						<Link href={`/bounty/${bounty.bountyAddress}`}>
+						{bounty.bountyTokenBalances?.length>1 && <Link href={`/bounty/${bounty.bountyAddress}`}>
 							<a target={'_blank'}>
 								<div onClick={closeModal} className="border border-web-gray px-4 pb-1.5 pt-1.5 w-max rounded-md cursor-pointer">more...
 								</div>
 							</a>
-						</Link>
+						</Link>}
 					</div>}
 					<section className="github_markup" dangerouslySetInnerHTML={{ __html: bounty.bodyHTML }}></section>
 				</div>

--- a/components/Bounty/BountyStatus.js
+++ b/components/Bounty/BountyStatus.js
@@ -32,8 +32,8 @@ const BountyStatus = ({ bounty }) => {
 				</div>
 			</div>
 			<div>
-				{bounty?<div className='text-white'>Issue created on {appState.utils.formatDate(bounty.createdAt)}</div> : <Skeleton width={'10rem'}/>}
-				{bounty?<div className='text-white'>Bounty minted on on {appState.utils.formatUnixDate(bounty.bountyMintTime)}</div> : <Skeleton width={'10rem'}/>}
+				{bounty?<div className='text-white'>Issue created on {appState.utils.formatDate(bounty.createdAt, true)}</div> : <Skeleton width={'10rem'}/>}
+				{bounty?<div className='text-white'>Bounty minted on on {appState.utils.formatUnixDate(bounty.bountyMintTime, true)}</div> : <Skeleton width={'10rem'}/>}
 			</div>
 		</>
 	);

--- a/components/Bounty/LabelsList.js
+++ b/components/Bounty/LabelsList.js
@@ -7,12 +7,12 @@ import Skeleton from 'react-loading-skeleton';
 const LabelsList = ({ bounty }) => {
 	return (
 		<div className="flex flex-row space-x-2">
-			<div className="space-x-2 space-y-2">
+			<div>
 				{bounty?.labels.map((label, index) => {
 					return (
 						<button
 							key={index}
-							className="rounded-lg text-xs py-1 px-2 font-bold border border-purple-500 text-white truncate"
+							className="rounded-lg text-xs mr-2 mb-px py-1 px-2 font-bold border border-purple-500 text-white truncate"
 							style={{
 								borderColor: `#${label.color}`,
 								opacity: .9,

--- a/components/Bounty/MiniDepositCard.js
+++ b/components/Bounty/MiniDepositCard.js
@@ -34,7 +34,7 @@ const MiniDepositCard = ({deposit, showLink, status})=>{
 
 	// render
 	return(
-		<div key={deposit.id} className={`bg-web-gray/20 ${(open && deposit) ? timeToExpiry < 604800 ? 'border-red-500' : timeToExpiry < 1209600 ? 'border-yellow-500' : 'border-green' : 'border-web-gray'} border px-8 py-4 pb-4 h-min rounded-md sm:w-72 text-white`}>		
+		<div key={deposit.id} className={`bg-web-gray/20 ${(open && deposit) ? timeToExpiry < 604800 ? 'border-red-500' : timeToExpiry < 1209600 ? 'border-yellow-500' : 'border-green' : 'border-web-gray'} border px-4 py-4 pb-4 h-min rounded-md sm:w-64 text-white lg:col-span-2 justify-self-center`}>		
 			{showLink&&<Link href={`/bounty/${deposit.bounty.id}`}>
 				<h3 className='text-xl font-semibold leading-none underline cursor-pointer pb-2'>{title}</h3>			
 			</Link>}

--- a/components/Bounty/MiniDepositCard.js
+++ b/components/Bounty/MiniDepositCard.js
@@ -8,7 +8,7 @@ import Skeleton from 'react-loading-skeleton';
 import StoreContext from '../../store/Store/StoreContext';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
 import TokenBalances from '../TokenBalances/TokenBalances';
-const MiniDepositCard = ({deposit, showLink})=>{
+const MiniDepositCard = ({deposit, showLink, status})=>{
 	// Context
 	const [appState] = useContext(StoreContext);
 
@@ -30,11 +30,11 @@ const MiniDepositCard = ({deposit, showLink})=>{
 	});
 
 	const timeToExpiry = parseInt(deposit.receiveTime) + parseInt(deposit.expiration) - Date.now()* 0.001 ;
-	const open = !deposit.refunded&&!deposit.claimed;
+	const open = !deposit.refunded && status==='OPEN';
 
 	// render
 	return(
-		<div key={deposit.id} className={`bg-web-gray/20 ${(open&&deposit) ? timeToExpiry < 604800 ? 'border-red-500' : timeToExpiry < 1209600 ? 'border-yellow-500' : 'border-green' : 'border-web-gray'} border px-8 py-4 my-4 pb-4 h-min rounded-md sm:w-72 text-white`}>		
+		<div key={deposit.id} className={`bg-web-gray/20 ${(open && deposit) ? timeToExpiry < 604800 ? 'border-red-500' : timeToExpiry < 1209600 ? 'border-yellow-500' : 'border-green' : 'border-web-gray'} border px-8 py-4 my-4 pb-4 h-min rounded-md sm:w-72 text-white`}>		
 			{showLink&&<Link href={`/bounty/${deposit.bounty.id}`}>
 				<h3 className='text-xl font-semibold leading-none underline cursor-pointer pb-2'>{title}</h3>			
 			</Link>}

--- a/components/Bounty/MiniDepositCard.js
+++ b/components/Bounty/MiniDepositCard.js
@@ -34,7 +34,7 @@ const MiniDepositCard = ({deposit, showLink, status})=>{
 
 	// render
 	return(
-		<div key={deposit.id} className={`bg-web-gray/20 ${(open && deposit) ? timeToExpiry < 604800 ? 'border-red-500' : timeToExpiry < 1209600 ? 'border-yellow-500' : 'border-green' : 'border-web-gray'} border px-8 py-4 my-4 pb-4 h-min rounded-md sm:w-72 text-white`}>		
+		<div key={deposit.id} className={`bg-web-gray/20 ${(open && deposit) ? timeToExpiry < 604800 ? 'border-red-500' : timeToExpiry < 1209600 ? 'border-yellow-500' : 'border-green' : 'border-web-gray'} border px-8 py-4 pb-4 h-min rounded-md sm:w-72 text-white`}>		
 			{showLink&&<Link href={`/bounty/${deposit.bounty.id}`}>
 				<h3 className='text-xl font-semibold leading-none underline cursor-pointer pb-2'>{title}</h3>			
 			</Link>}

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -2,7 +2,8 @@
 import React from 'react';
 import Link from 'next/link';
 
-const BountyClosed = ({ bounty }) => {
+const BountyClosed = ({ bounty, showTweetLink }) => {
+	console.log(bounty);
 	// Hooks
 	const tweetText = 'Just claimed a developer bounty from on OpenQ for : ';
 	const url = `${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/tx/${bounty.claimedTransactionHash}`;
@@ -13,7 +14,16 @@ const BountyClosed = ({ bounty }) => {
 				<h2 className="flex text-3xl font-semibold text-white justify-center pt-16">Bounty Closed</h2>
 				<div className="bg-claimed-bounty-inside col-span-3 border border-claimed-bounty rounded-lg text-white p-4">
 					<div className='flex justify-between w-full'>
-						{true && <Link
+						<p>Closing Transaction: <Link href={url}>
+							<span className="cursor-pointer break-words">
+								<span className="underline">{url}</span>
+								{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
+								</svg>
+							</span>
+						</Link>
+
+						</p>
+						{showTweetLink && <Link
 							href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyAddress}`}
 
 						>
@@ -27,16 +37,6 @@ const BountyClosed = ({ bounty }) => {
 							</a>
 						</Link>}
 					</div>
-					<p>Closing Transaction: <Link href={url}>
-						<span className="cursor-pointer break-words">
-							<span className="underline">{url}</span>
-							{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
-							</svg>
-						</span>
-					</Link>
-
-					</p>
-					<p className="text-right w-full">{ }	</p>
 				</div>
 			</div>
 		</div>

--- a/components/Claim/ClaimLoadingModal.js
+++ b/components/Claim/ClaimLoadingModal.js
@@ -98,7 +98,7 @@ const ClaimLoadingModal = ({ confirmMethod, url, ensName, account, claimState, a
 							</div>
 						) : null}
 						
-						{claimState===CHECKING_WITHDRAWAL_ELIGIBILITY &&
+						{(claimState===CHECKING_WITHDRAWAL_ELIGIBILITY || claimState === TRANSACTION_SUBMITTED) &&
 						<div className='self-center'><LoadingIcon bg="colored" /></div>
 						}
 					</div>

--- a/components/Loading/LoadingModal.js
+++ b/components/Loading/LoadingModal.js
@@ -1,0 +1,34 @@
+// Third Party
+import React from 'react';
+import LoadingIcon from './ButtonLoadingIcon';
+
+const LoadingModal = ({  loadingText, updateModal }) => {
+	const { title, message } = loadingText;
+
+	
+
+	return (
+		<div>
+			<div onClick={()=>updateModal()}className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
+				<div className="w-auto my-6 mx-auto max-w-3xl">
+					<div className="border-0 rounded-lg shadow-lg  flex flex-col w-full bg-dark-mode  outline-none focus:outline-none">
+						<div className="flex items-start justify-center p-5">
+							<h3 className="text-3xl font-semibold text-white">{title}</h3>
+						</div>
+						<div className="p-4 flex-auto">
+							<p className="text-white text-lg leading-relaxed">
+								{message}
+							</p>
+						</div>
+						<div className="flex items-center justify-center pb-6">
+							<LoadingIcon />
+						</div>
+					</div>
+				</div>
+			</div>
+			<div className="fixed inset-0 bg-overlay"></div>
+		</div>
+	);
+};
+
+export default LoadingModal;

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -152,7 +152,7 @@ const MintBountyModal = ({ modalVisibility }) => {
 
 			await sleep(1000);
 
-
+			sessionStorage.setItem('justMinted', true);
 			router.push(
 				`${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bountyAddress}?first=true`
 			);

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -150,13 +150,6 @@ const MintBountyModal = ({ modalVisibility }) => {
 				mintBountyState.orgId
 			);
 
-			let bountyId = null;
-			while (bountyId == 'undefined') {
-				const bountyResp = await appState.openQSubgraphClient.getBounty(bountyAddress);
-				bountyId = bountyResp?.bountyId;
-				await sleep(500);
-			}
-
 			await sleep(1000);
 
 

--- a/components/Organization/LargeOrganizationCard.js
+++ b/components/Organization/LargeOrganizationCard.js
@@ -14,7 +14,7 @@ const LargeOrganizationCard = ({ organization }) => {
 
 	// Render
 	return (
-		<div className='w-min justify-self-end hidden xl:block mr-8'>
+		<div className='w-min justify-self-end hidden 2xl:block mr-8'>
 			<div
 				className={
 					'flex flex-col p-10 items-center font-mont rounded-lg shadow-sm border border-web-gray pr-11 pl-11'

--- a/pages/bounty/[address].js
+++ b/pages/bounty/[address].js
@@ -85,9 +85,9 @@ const address = () => {
 
 		// Confetti
 		const justMinted = sessionStorage.getItem('justMinted')==='true';
-		setIsIndexing(justMinted);
 		sessionStorage.setItem('justMinted', false);
 		if (justMinted) {
+			setIsIndexing(true);
 			canvas.current.width = window.innerWidth;
 			canvas.current.height = window.innerHeight;
 

--- a/pages/bounty/[address].js
+++ b/pages/bounty/[address].js
@@ -25,7 +25,7 @@ const address = () => {
 	const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances);
 
 	// State
-	const { address, first, } = router.query;
+	const { address } = router.query;
 	const [, setRedirectUrl] = useState('');
 	const [, setIsLoading] = useState(true);
 	const [error, setError] = useState(false);
@@ -45,12 +45,7 @@ const address = () => {
 			// or is it null?
 			while (bounty === undefined || bounty === null) {
 				bounty = await appState.openQSubgraphClient.getBounty(address);
-				if(first){
-					if(!bounty){
-						setIsIndexing(true);
-					}
-				}
-				else{
+				if(bounty){
 					setIsIndexing(false);
 				}
 				await sleep(500);				
@@ -87,16 +82,12 @@ const address = () => {
 
 	// Hooks
 	useEffect(() => {
-		if (address) {
-			const route = sessionStorage.getItem(address);
 
-			if (route !== internalMenu) {
-				setInternalMenu(route || 'View');
-			}
-			setRedirectUrl(`${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${address}`);
-			populateBountyData();
-		}
-		if (first) {
+		// Confetti
+		const justMinted = sessionStorage.getItem('justMinted')==='true';
+		setIsIndexing(justMinted);
+		sessionStorage.setItem('justMinted', false);
+		if (justMinted) {
 			canvas.current.width = window.innerWidth;
 			canvas.current.height = window.innerHeight;
 
@@ -112,6 +103,16 @@ const address = () => {
 					y: 0,
 				}
 			});
+		}
+		// set route and populate
+		if (address) {
+			const route = sessionStorage.getItem(address);
+
+			if (route !== internalMenu) {
+				setInternalMenu(route || 'View');
+			}
+			setRedirectUrl(`${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${address}`);
+			populateBountyData();
 		}
 	}, [address]);
 

--- a/services/subgraph/graphql/query.js
+++ b/services/subgraph/graphql/query.js
@@ -287,64 +287,8 @@ export const GET_ORGANIZATIONS = gql`
 query GetOrganizations {
   organizations {
     id
-		fundedTokenBalances {
-      id
-      tokenAddress
-      volume
-    }
-    deposits {
-      id
-			refunded
-			refundTime
-      tokenAddress
-      volume
-			expiration
-			receiveTime
-      bounty {
-        id
-        bountyId
-      }
-      sender {
-        id
-      }
-    }
-    payouts {
-      id
-      tokenAddress
-      payoutTime
-      volume
-    }
-		payoutTokenBalances {
-		  id
-      volume
-      tokenAddress
-		}
     bountiesCreated {
 			bountyAddress
-			bountyId
-			bountyMintTime
-			bountyClosedTime
-			claimedTransactionHash
-			status
-			deposits {
-				id
-				tokenAddress
-				volume
-				expiration
-				refunded
-				refundTime
-				sender {
-					id
-				}
-				receiveTime
-			}
-			issuer {
-				id
-			}
-			bountyTokenBalances {
-				volume
-				tokenAddress
-			}
     }
   }
 }

--- a/services/utils/Utils.js
+++ b/services/utils/Utils.js
@@ -5,7 +5,7 @@ class Utils {
 		'July', 'August', 'September', 'October', 'November', 'December'
 	];
 
-	formatUnixDate = (unixTime) => {
+	formatUnixDate = (unixTime, hideDate) => {
 		var date = new Date(unixTime * 1000);
 
 		var day = date.getDate();
@@ -20,12 +20,15 @@ class Utils {
 		var seconds = '0' + date.getSeconds();
 
 		// Will display time in 10:30:23 format
+		if(hideDate){
+			return `${month} ${day}, ${year}`;
+		}
 		var formattedTime = `${month} ${day}, ${year} at ${hours}:${minutes.substr(-2) + ':' + seconds.substr(-2)}`;
 		return formattedTime;
 	};
 
-	formatDate = (createdAt) => {
-		return this.formatUnixDate(new Date(createdAt).getTime() / 1000);
+	formatDate = (createdAt, hideDate) => {
+		return this.formatUnixDate(new Date(createdAt).getTime() / 1000, hideDate);
 	};
 
 	issurUrlRegex = (issueUrl) => {


### PR DESCRIPTION
Closes #232 by adding indexing modal to pages/bounty/[address].
Closes #233 by fixing formatting of twitter link ( closer does not seem to be accessible in our queries anymore ) and adding spinner when claimBountyState is TRANSACTION_SUBMITTED (this needs to be tested in dev);
Removes confetti showing up on every reload after first minting of bounty.
Also added gray border on deposit cards when claimed, hide org card at small screen sizes (to prevent overflow), solidfied layout of BountyDetails page, optimized org query for org homepage, and removed times from dates.