### PR TITLE
uses txnReceipt.events[1].args.bountyAddress instead of simply address

### DIFF
--- a/services/ethers/OpenQClient.js
+++ b/services/ethers/OpenQClient.js
@@ -39,7 +39,7 @@ class OpenQClient {
 				const txnReceipt = await txnResponse.wait();
 
 				console.log(txnReceipt);
-				const bountyAddress = txnReceipt.events[1].address;
+				const bountyAddress = txnReceipt.events[1].args.bountyAddress;
 				resolve({ bountyAddress });
 			} catch (err) {
 				console.log(err);


### PR DESCRIPTION
This kept getting overwritten on our merges for some reason.

Let's review and merge now to put an end to it!