### PR TITLE
wallet connect buttons centered

### DIFF
--- a/components/WalletConnect/ConnectModal.js
+++ b/components/WalletConnect/ConnectModal.js
@@ -31,20 +31,20 @@ const ConnectModal = ({closeModal})=>{
 					</div>
 					<h2 className='text-xl font-bold'>Connect Wallet</h2>
 					<p className='text-sm'>Connect your wallet to continue with OpenQ. By connecting your wallet you agree with OpenQ{'\''}s terms of service.</p>
-					<button onClick={handleMetaMask} className='flex p-2 mt-4  my-2 w-60 gap-4 hover:bg-inactive-accent/10 rounded-md'>
+					<button onClick={handleMetaMask} className='flex p-2 mt-4  my-2 w-full gap-4 hover:bg-inactive-accent/10 rounded-md hover:border-web-gray border border-transparent justify-center'>
 						<Image src={'/wallet-logos/metamask.png'} height={40} width={40} alt={'metamask logo'}/>
 						<div className='text-xl leading-loose'>
 							Metamask
 						</div>
 					</button>
-					<button onClick={handleWalletConnect} className='flex p-2 mb-4 w-60 gap-4 hover:bg-inactive-accent/10 rounded-md'>
+					<button onClick={handleWalletConnect} className='flex p-2 mb-4 w-full gap-4 hover:bg-inactive-accent/10 rounded-md hover:border-web-gray border border-transparent justify-center'>
 						<Image src={'/wallet-logos/wallet-connect.jpg'} className="rounded-full" height={40} width={40} alt={'wallet connect logo'}/>
 						<div className='leading-loose text-xl'>
 							WalletConnect
 						</div>
 					</button>
 					<button onClick={closeModal} className='self-center border border-inactive-accent font-semibold w-32 rounded-full py-1 px-2 bg-inactive-accent-inside group-hover:bg-active-accent hover:border-active-accent group-hover:border-active-accent'>
-							Back
+							Close
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #352
Wallet connect buttons centered, highlight modified and text "Back" changed to "Close"
Note: web-gray border appears only on hover (my assumption)

Additional question:
- I was unable to "disconnect" the sample wallet from the initial state => is "deactivate" from the web3-react package still working as intended (I didn't see any "deactivate" exported in the "core" package on the web3-React github, but we seem to import in from there in useWeb3.js). I had to momentarily comment out code in ConnectButton.js to be able to see the relevant front-end part.