### PR TITLE
fixed issue where deleted bounties were breaking search

### DIFF
--- a/components/Bounty/BountyList.js
+++ b/components/Bounty/BountyList.js
@@ -12,7 +12,6 @@ import useWeb3 from '../../hooks/useWeb3';
 
 const BountyList = ({ bounties, watchedBounties,  loading, complete, getMoreData, getNewData, addCarousel }) => {
 	// Hooks
-	console.log(bounties);
 	const {account} = useWeb3();
 	const [unfundedVisible, setUnfundedVisible] = useState(false);
 	const [claimedVisible, setClaimedVisible] = useState(false);

--- a/pages/index.js
+++ b/pages/index.js
@@ -61,9 +61,11 @@ export default function Index({orgs, fullBounties, batch }) {
 		newBounties.forEach((bounty) => {
 			const relatedIssue = issueData.find(
 				(issue) => issue.id == bounty.bountyId
-			) || { id: '', title: '', body: '' };
-			const mergedBounty = { ...bounty, ...relatedIssue };
-			fullBounties.push(mergedBounty);
+			); 
+			if(relatedIssue){
+				const mergedBounty = { ...bounty, ...relatedIssue };
+				fullBounties.push(mergedBounty);
+			}
 		});
 		return fullBounties;
 	}
@@ -79,7 +81,7 @@ export default function Index({orgs, fullBounties, batch }) {
 	async function getMoreData(order) {
 		setComplete(true);
 		const newBounties = await getBountyData(order, pagination);
-		if (newBounties.length === batch) {
+		if (newBounties.length !==0) {
 			setComplete(false);
 		}
 		setBounties(bounties.concat(newBounties));
@@ -180,9 +182,11 @@ export const getServerSideProps = async()=>{
 		newBounties.forEach((bounty) => {
 			const relatedIssue = issueData.find(
 				(issue) => issue.id == bounty.bountyId
-			) || { id: '', title: '', body: '' };
-			const mergedBounty = { ...bounty, ...relatedIssue };
-			fullBounties.push(mergedBounty);
+			);
+			if(relatedIssue){
+				const mergedBounty = { ...bounty, ...relatedIssue };
+				fullBounties.push(mergedBounty);
+			}
 		});
 	}
 	catch(err){

--- a/pages/organization/[organization].js
+++ b/pages/organization/[organization].js
@@ -38,10 +38,12 @@ const organization = ({ organizationData, fullBounties, completed, batch, render
 		newBounties.bountiesCreated.forEach((bounty) => {
 			const relatedIssue = issueData.find(
 				(issue) => issue.id == bounty.bountyId
-			)|| { id: '', title: '', body: '' };
-			const mergedBounty = { ...bounty, ...relatedIssue };
-			fullBounties.push(mergedBounty);
-		});
+			);
+			if(relatedIssue){
+				const mergedBounty = { ...bounty, ...relatedIssue };
+				fullBounties.push(mergedBounty);}
+		
+		}	);
 		return fullBounties;
 	}
 
@@ -53,6 +55,7 @@ const organization = ({ organizationData, fullBounties, completed, batch, render
 			newBounties = await getBountyData(order, 0);
 		}
 		catch (err) {
+			console.log(err);
 			setError(true);
 			return;
 		}
@@ -70,7 +73,7 @@ const organization = ({ organizationData, fullBounties, completed, batch, render
 			setError(true);
 			return;
 		}
-		if (newBounties.length === batch) {
+		if (newBounties.length !== 0) {
 			setComplete(false);
 		}
 		setBounties(bounties.concat(newBounties));
@@ -131,9 +134,11 @@ export const getServerSideProps = async(context) =>{
 	bounties.forEach((bounty) => {
 		const relatedIssue = issueData.find(
 			(issue) => issue.id == bounty.bountyId
-		) || { id: '', title: '', body: '' };
-		const mergedBounty = { ...bounty, ...relatedIssue };
-		fullBounties.push(mergedBounty);
+		);
+		if(relatedIssue){
+			const mergedBounty = { ...bounty, ...relatedIssue };
+			fullBounties.push(mergedBounty);
+		}
 	});
 
 


### PR DESCRIPTION
Fixes issue where deleted issues were breaking search.  
Solved this by filtering through the bounties when they are merged on the FE.
With my implementation it is possible to break pagination, because pagination just looks at the number of merged bounties to see whether it needs to pull more. Right now if there are ten deleted bounties pagination will be set as completed and won't pull anymore.