### PR TITLE
correction of truncate 0

### DIFF
--- a/components/TokenBalances/TokenBalances.js
+++ b/components/TokenBalances/TokenBalances.js
@@ -34,7 +34,9 @@ const TokenBalances = ({ tokenBalances, tokenValues, header, singleCurrency, sho
 					totalValue = (formattedVolume * tokenValues?.tokenPrices[tokenValueAddress]).toFixed(2);
 				}
 
-				formattedVolume = parseFloat(Number(formattedVolume).toFixed(10)).toFixed(2);
+				formattedVolume = Number.isInteger(Number(formattedVolume * 10)) ?
+          Number(formattedVolume).toFixed(2)
+          : parseFloat(Number(formattedVolume).toFixed(10));
 
 				let usdValue = appState.utils.formatter.format(
 					totalValue


### PR DESCRIPTION
Re - Closes #445 
Previous code was to simplistic to set decimals to 2

Note: for very small numbers parseFloat forces scientific notation. If there are many different types of values (very small, very big...) it might look a bit chaotic overall. 