### PR TITLE
Fixed integration issues on new-design - 2 

### DIFF
--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -7,26 +7,33 @@ import StoreContext from '../../store/Store/StoreContext';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
 import BountyMetadata from './BountyMetadata.js';
 import useWeb3 from '../../hooks/useWeb3';
+import useEns from '../../hooks/useENS';
 
 
 const BountyCardDetails = ({ bounty, setInternalMenu }) => {
 	const [appState] = useContext(StoreContext);
 	const {account} = useWeb3();
-	const sender = bounty?.issuer?.id || account;
+	const [ensName] = useEns(bounty?.issuer?.id || account);
+	const sender = ensName ||bounty?.issuer?.id || account;
 	const [tokenValues] = useGetTokenValues(bounty.bountyTokenBalances||[]);
 	const deposits = bounty.deposits ||[];
+	const refunds = bounty.refunds || [];
+
+	const actions = appState.utils.mergeOrdered(deposits, refunds, 'receiveTime', 'refundTime');
+
 	const addresses = deposits.reduce((accum, elem)=>{
 		if(accum.includes(elem.sender.id)){
 			return accum;}
 		return [...accum, elem.sender.id];
 	},[sender?.toLowerCase()]);
 	
+	
 	return (
 		<div className='flex w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
 			{sender && <div className='flex-1 pr-4 min-w-[260px]'>
-				{deposits.reverse().map((deposit, index)=><ActionBubble key={index} address={deposit.sender.id} deposit={deposit} title={`${(deposit.sender.id).slice(0, 4)}...${(deposit.sender.id).slice(38)} funded 3 Matic ($200 USD)`}/> )}
+				<ActionBubble addresses={addresses} address={sender} price={tokenValues?.total}  title = {`${ensName ||`${(sender).slice(0, 4)}...${(sender).slice(38)}`} minted this contract ${appState.utils.formatUnixDate(bounty.bountyMintTime)}.`} bodyHTML={bounty.bodyHTML}/>
+				{actions.map((action, index)=><ActionBubble address={action.sender?.id ||sender } key={index}  action={action} /> )}
 		
-				<ActionBubble addresses={addresses} address={sender} price={tokenValues?.total}  title = {`${(sender).slice(0, 4)}...${(sender).slice(38)} minted this contract ${appState.utils.formatUnixDate(bounty.bountyMintTime)}.`} bodyHTML={bounty.bodyHTML}/>
 			</div>}
 			<BountyMetadata bounty={bounty} setInternalMenu={setInternalMenu} price={tokenValues?.total}/>
 		</div>

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -10,31 +10,31 @@ import useWeb3 from '../../hooks/useWeb3';
 import useEns from '../../hooks/useENS';
 
 
-const BountyCardDetails = ({ bounty, setInternalMenu }) => {
+const BountyCardDetails = ({ bounty, setInternalMenu, justMinted }) => {
 	const [appState] = useContext(StoreContext);
 	const {account} = useWeb3();
-	const [ensName] = useEns(bounty?.issuer?.id || account);
-	const sender = ensName ||bounty?.issuer?.id || account;
+	const [ensName] = useEns(bounty?.issuer?.id);
+	const sender = ensName ||bounty?.issuer?.id;
 	const [tokenValues] = useGetTokenValues(bounty.bountyTokenBalances||[]);
 	const deposits = bounty.deposits ||[];
 	const refunds = bounty.refunds || [];
-
+	const title = sender|| justMinted ? `${ensName ||`${(sender||account).slice(0, 4)}...${(sender||account).slice(38)}`} minted this contract${sender ? ' '.concat(appState.utils.formatUnixDate(bounty.bountyMintTime)): ''}.`: 'Waiting for graph to index contract data.';
 	const actions = appState.utils.mergeOrdered(deposits, refunds, 'receiveTime', 'refundTime');
 
 	const addresses = deposits.reduce((accum, elem)=>{
 		if(accum.includes(elem.sender.id)){
 			return accum;}
 		return [...accum, elem.sender.id];
-	},[sender?.toLowerCase()]);
+	},[sender?.toLowerCase()||(justMinted && account)]);
 	
 	
 	return (
 		<div className='flex w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
-			{sender && <div className='flex-1 pr-4 min-w-[260px]'>
-				<ActionBubble addresses={addresses} address={sender} price={tokenValues?.total}  title = {`${ensName ||`${(sender).slice(0, 4)}...${(sender).slice(38)}`} minted this contract ${appState.utils.formatUnixDate(bounty.bountyMintTime)}.`} bodyHTML={bounty.bodyHTML}/>
+			<div className='flex-1 pr-4 min-w-[260px]'>
+				<ActionBubble  addresses={addresses} address={sender} price={tokenValues?.total}  title = {title} bodyHTML={bounty.bodyHTML}/>
 				{actions.map((action, index)=><ActionBubble address={action.sender?.id ||sender } key={index}  action={action} /> )}
 		
-			</div>}
+			</div>
 			<BountyMetadata bounty={bounty} setInternalMenu={setInternalMenu} price={tokenValues?.total}/>
 		</div>
 

--- a/components/Bounty/BountyHeading.js
+++ b/components/Bounty/BountyHeading.js
@@ -4,30 +4,34 @@ import Link from 'next/link';
 // Custom
 import MintBountyButton from '../MintBounty/MintBountyButton';
 import StoreContext from '../../store/Store/StoreContext';
-const BountyHeading = ({bounty, price}) =>{
+const BountyHeading = ({bounty, price, justMinted}) =>{
 
 	const [appState] = useContext(StoreContext);
 	return (
 		<div className='sm:px-8 px-4 w-full max-w-[1200px] pb-4'>
 			<div className='pt-6 pb-2 w-full flex flex-wrap'>
 				<h1 className='text-[32px] flex-1 leading-tight min-w-[240px]'><span className='text-primary'>{bounty.title} </span>
-					<Link href={bounty.url} className='text-muted text font-light'><a className='text-link-colour hover:underline'>#{bounty.number}</a></Link>
+					<Link href={bounty.url} className='text-muted text font-light'>
+						<a className='text-link-colour hover:underline' rel="noopener norefferer" target="_blank">
+						#{bounty.number}
+						</a>
+					</Link>
 				</h1>
 				<MintBountyButton styles={'h-8 self-center'}/>
 			</div>
 			<div className='w-full flex flex-wrap justify-between w-full pb-4 border-b border-web-gray'>
-				<div className={`${bounty.status === 'OPEN' ? 'bg-important-button': 'bg-closed'} py-2 font-light rounded-full px-4 flex gap-1  w-fit`}>
+				<div className={`${bounty.status === 'OPEN' || justMinted ? 'bg-important-button': 'bg-closed'} py-2 font-light rounded-full px-4 flex gap-1  w-fit`}>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" className='fill-white'>
 						<path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fillRule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z">
 						</path></svg>
 		
 					<span className='leading-none'>
-						{bounty.status === 'OPEN' ? 'Open': 'Claimed'}</span>
+						{bounty.status === 'OPEN' || justMinted ? 'Open': 'Claimed'}</span>
 				</div>
 
 				<span className='leading-loose text-lg font-semibold text-primary'>
 					
-					Total Value {bounty.status === 'OPEN' ? 'Locked': 'Claimed'} { appState.utils.formatter.format(
+					Total Value {bounty.status === 'OPEN' || justMinted  ? 'Locked': 'Claimed'} { appState.utils.formatter.format(
 						price||0
 					)}</span>
 			</div>

--- a/components/Bounty/BountyHeading.js
+++ b/components/Bounty/BountyHeading.js
@@ -4,7 +4,7 @@ import Link from 'next/link';
 // Custom
 import MintBountyButton from '../MintBounty/MintBountyButton';
 import StoreContext from '../../store/Store/StoreContext';
-const BountyHeading = ({bounty, price, justMinted}) =>{
+const BountyHeading = ({bounty, price}) =>{
 
 	const [appState] = useContext(StoreContext);
 	return (
@@ -20,18 +20,18 @@ const BountyHeading = ({bounty, price, justMinted}) =>{
 				<MintBountyButton styles={'h-8 self-center'}/>
 			</div>
 			<div className='w-full flex flex-wrap justify-between w-full pb-4 border-b border-web-gray'>
-				<div className={`${bounty.status === 'OPEN' || justMinted ? 'bg-important-button': 'bg-closed'} py-2 font-light rounded-full px-4 flex gap-1  w-fit`}>
+				<div className={`${bounty.status === 'CLOSED' ? 'bg-closed':'bg-important-button'} py-2 font-light rounded-full px-4 flex gap-1  w-fit`}>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" className='fill-white'>
 						<path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path><path fillRule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z">
 						</path></svg>
 		
 					<span className='leading-none'>
-						{bounty.status === 'OPEN' || justMinted ? 'Open': 'Claimed'}</span>
+						{bounty.status === 'CLOSED' ?'Claimed' : 'Open' }</span>
 				</div>
 
 				<span className='leading-loose text-lg font-semibold text-primary'>
 					
-					Total Value {bounty.status === 'OPEN' || justMinted  ? 'Locked': 'Claimed'} { appState.utils.formatter.format(
+					Total Value {bounty.status === 'CLOSED'  ? 'Claimed': 'Locked' } { appState.utils.formatter.format(
 						price||0
 					)}</span>
 			</div>

--- a/components/BountyCard/BountyModalHeading.js
+++ b/components/BountyCard/BountyModalHeading.js
@@ -87,7 +87,7 @@ const BountyModalHeading = ({bounty, closeModal, unWatchable})=>{
 				
 				</span>
 				<h2 className='text-xl flex-1 leading-tight md:w-96'><span className='flex text-primary break-word'>{bounty.title} </span>
-					<Link href={bounty.url} className='text-muted text font-light'><a className='text-link-colour hover:underline'>#{bounty.number}</a></Link>
+					<Link href={bounty.url} className='text-muted text font-light'><a target="_blank" className='text-link-colour hover:underline'>#{bounty.number}</a></Link>
 				</h2>
 			</div>
 			<div className='min-w-[40px]  flex flex-wrap sm:flex-nowrap gap-x-4 gap-y-2'>

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -22,7 +22,7 @@ const Navigation = () => {
 	const { account, activate, deactivate } = useWeb3();
 	const [appState] = useContext(StoreContext);
 	const [openMenu, setOpenMenu] = useState(false);
-	const [quickSearch, setQuickSearch] = useState();
+	const [quickSearch, setQuickSearch] = useState('');
 	const [items, setItems] = useState([]);
 	const [searchable, setSearchable] = useState();
 

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -146,9 +146,9 @@ const Navigation = () => {
 						</button>
 
 						<div className="md:flex hidden  content-center  items-center">
-							<div className='flex-col justify-center mr-2 h-7  group'>
+							<div className='flex-col justify-center mr-2 h-7 group '>
 								<input
-									className="md:flex hidden pr-24 items-center input-field"
+									className={`md:flex hidden pr-24 items-center focus:w-80 w-60  left-0 input-field transition-all  ease-in-out duration-700 ${quickSearch && 'focus:w-96'}`}
 									onChange={handleSearch}
 									value={quickSearch}
 									type="text"

--- a/components/MintBounty/IssueDetailsBubble.js
+++ b/components/MintBounty/IssueDetailsBubble.js
@@ -27,7 +27,7 @@ export default function IssueDetailsBubble({ issueData }) {
 				</div>
 				<div className="text-xs pt-3 pl-6 text-gray-200">
 					{' '}
-											created at {appState.utils.formatDate(issueData.createdAt)} { issueData.author && `by ${issueData.author.login}`}
+											Created on {appState.utils.formatDate(issueData.createdAt)} { issueData.author && `by ${issueData.author.login}`}
 				</div>
 			</div>
 		</>

--- a/components/Organization/starOrganization.js
+++ b/components/Organization/starOrganization.js
@@ -1,7 +1,14 @@
 import axios from 'axios';
  
 const starOrganization = async (account, id, starred, setStarred, setStarredDisabled, context) => {
-	const [appState, dispatch] = context;
+	const [appState, dispatch] = context;	
+	if(!account){const payload = {
+		type: 'CONNECT_WALLET',
+		payload: true
+	};
+	dispatch(payload);
+	return; 
+	}
 	const signMessage = async () => {
 		const message = 'OpenQ';
 		const signature = await window.ethereum

--- a/components/Stream/ApproveStreamModal.js
+++ b/components/Stream/ApproveStreamModal.js
@@ -81,7 +81,7 @@ const ApproveStreamModal = ({
 	let fundStyles = {
 		[CONFIRM]: 'px-8 border-transparent',
 		[APPROVING]: 'px-8 border-transparent hover:cursor-default',
-		[TRANSFERRING]: 'btn-primary border-button hover:cursor-default'
+		[TRANSFERRING]: 'btn-primary hover:cursor-default'
 	};
 	if ('0x0000000000000000000000000000000000000000' === token.address) {
 		fundStyles = { ...approveStyles };

--- a/components/Stream/Stream.js
+++ b/components/Stream/Stream.js
@@ -26,7 +26,7 @@ const Stream = ({stream, direction})=>{
 	</div>
 	<div>Flow Rate: {parseInt(stream.currentFlowRate)*10**(- 1 * stream.token.decimals)*24*60*60}/day</div>
 	<div>Total deposit: {parseInt(stream.deposit)*10**(- 1 * stream.token.decimals)}</div>
-	<div>Created at {readableTime}</div>
+	<div>Created on {readableTime}.</div>
 	</div>);
 };
 export default Stream;

--- a/components/Stream/Stream.js
+++ b/components/Stream/Stream.js
@@ -18,7 +18,7 @@ const Stream = ({stream, direction})=>{
 			iconWrapper.current.appendChild(jazzicon(32, parseInt(otherAccount?.id?.slice(2, 10), 16)));
 		}
 	}, [stream?.receiver?.id]);
-	return (<div className='p-4 w-fit border border-web-gray rounded-lg'><div className='flex gap-8 space-between w-full'>
+	return (<div className='p-4 w-fit border border-web-gray rounded-sm'><div className='flex gap-8 space-between w-full'>
 		<div className='flex gap-2'><Image height={32} width={32} src={path}/><div className="pt-2">{name}</div></div>
 		<span className='pt-2'>{direction==='in'? 'From' : 'To'}</span>
 		<div className='flex gap-2'>

--- a/components/Stream/ViewStream.js
+++ b/components/Stream/ViewStream.js
@@ -18,12 +18,12 @@ const ViewStreams = () => {
 		<div className="mt-8">
 			
 			<section>
-				<h2 className='text-center font-bold text-tinted text-3xl'>{superfluidData?.length ? 'Your': 'No'} Inflows</h2>
+				<h2 className='text-left font-semibold text-primary text-2xl'>{superfluidData?.inflows?.length>0 ? 'Your': 'No'} Inflows</h2>
 				<div className='my-8'>	{superfluidData&&superfluidData.inflows.map((elem, index)=><Stream key={index}  direction={'in'} stream ={elem}/>)}</div>
 			</section>
 
 			<section>
-				<h2 className='text-center font-bold text-tinted text-3xl'>{superfluidData?.length ? 'Your': 'No'} Outflows</h2>
+				<h2 className='text-left font-semibold text-primary text-2xl'>{superfluidData?.outflows?.length>0 ? 'Your': 'No'} Outflows</h2>
 				<div className='my-8 grid grid-cols-[1fr_1fr_1fr] w-full flex-wrap gap-8 justify-center'>	{superfluidData&&superfluidData.outflows.map((elem, index)=><Stream key={index} direction={'out'} stream ={elem}/>)}</div>
 			</section>
 		

--- a/components/Utils/ActionBubble.js
+++ b/components/Utils/ActionBubble.js
@@ -1,26 +1,26 @@
 import React, { useContext } from 'react';
+import Skeleton from 'react-loading-skeleton';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
 import StoreContext from '../../store/Store/StoreContext';
 import Jazzicon from './Jazzicon';
 
 
-const ActionBubble = ({address, addresses, title, bodyHTML, body, deposit})=>{
+const ActionBubble = ({address, addresses, title, bodyHTML, body, action})=>{
 	let currentTitle = title;
-	const [tokenValues] = useGetTokenValues(deposit);
-	
+	const [tokenValues] = useGetTokenValues(action);
 	const [appState] = useContext(StoreContext);
-	if(deposit)
+	if(action)
 	{
-		const metadata = appState.tokenClient.getToken(deposit.tokenAddress);
-		const readableVolume = deposit.volume*(10**(-1*metadata.decimals));
-		currentTitle = `Funded ${readableVolume} ${metadata.name} (${ appState.utils.formatter.format(
-			tokenValues?.total)}) on ${appState.utils.formatUnixDate(deposit.receiveTime)}.`;
+		const metadata = appState.tokenClient.getToken(action.tokenAddress);
+		const readableVolume = action.volume*(10**(-1*metadata.decimals));
+		currentTitle = `${action.receiveTime ?'Funded': 'Refunded' } ${readableVolume} ${metadata.name} (${ appState.utils.formatter.format(
+			tokenValues?.total)}) on ${appState.utils.formatUnixDate(action.receiveTime||action.refundTime)}.${action.receiveTime && !action.refunded ? ` Locked until ${appState.utils.formatUnixDate(parseInt(action.receiveTime)+parseInt(action.expiration))}.`: ''}`;
 	}
 	return (
 		<div className='w-full pt-4 flex relative'>
-			{deposit ? 
+			{action ? 
 				<Jazzicon styles={'w-fit'} size={36} address={address} /> :
-				<div className='relative w-9'>	
+				<div className='relative w-9'>
 					{addresses.reverse().map((address, index)=>{						
 						return 	<div key={index} className={`h-4 w-10 z-${30-index*10} bg-transparent cursor-pointer relative hover:z-40`}>
 							
@@ -31,8 +31,9 @@ const ActionBubble = ({address, addresses, title, bodyHTML, body, deposit})=>{
 				</div>
 			}
 			<div className='w-full flex-0 rounded-sm overflow-hidden ml-4 border-web-gray border-b before:w-2 before:h-2 before:bg-nav-bg before:absolute before:absolute before:left-12 before:top-[35px] before:border-b  before:border-l before:border-web-gray before:top-10 before:rotate-45  border'>
-				<div className={`bg-nav-bg w-full py-2 pl-3 ${(body || bodyHTML) && 'border-web-gray border-b'} `}>
-					{currentTitle}
+				<div className={`bg-nav-bg w-full pl-3 ${(body || bodyHTML) && 'border-web-gray border-b'} flex justify-between`}>
+					<span className='py-2'>{tokenValues || title ? currentTitle : <Skeleton width="34" />}</span>
+					{action?.refunded && <span className='border rounded-full border-web-gray px-2 py-px m-1'> Refunded</span>}
 				</div>
 				{bodyHTML&&<div className='w-full p-4 markdown-body' dangerouslySetInnerHTML={{__html: bodyHTML }}></div>
 				}

--- a/pages/bounty/[id]/[address].js
+++ b/pages/bounty/[id]/[address].js
@@ -36,6 +36,7 @@ const address = ({ address, mergedBounty, renderError }) => {
 	// State
 	const [error, setError] = useState(renderError);
 	const [internalMenu, setInternalMenu] = useState();
+	const [justMinted, setJustMinted] = useState();
 
 	// Refs
 	const canvas = useRef();
@@ -117,6 +118,7 @@ const address = ({ address, mergedBounty, renderError }) => {
 		// Confetti
 		const justMinted = sessionStorage.getItem('justMinted') === 'true';
 		if (justMinted && canvas.current) {
+			setJustMinted(true);
 			setReload();
 			canvas.current.width = window.innerWidth;
 			canvas.current.height = window.innerHeight;
@@ -168,8 +170,8 @@ const address = ({ address, mergedBounty, renderError }) => {
 					<RepoTitle bounty={bounty} />
 					<SubMenu colour="rust" items={[{name: 'View', Svg: Telescope },{name: 'Fund', Svg: Add },{name: 'Refund', Svg: Subtract },{name: 'Claim', Svg: Fire },]} internalMenu={internalMenu} updatePage={setInternalMenu}/>
 					
-					<BountyHeading price={tokenValues?.total} justMinted={!bounty.issuer} bounty={bounty} />
-					{internalMenu == 'View' && <BountyCardDetails bounty={bounty} setInternalMenu={setInternalMenu} address={address} tokenValues={tokenValues} internalMenu={internalMenu} />}
+					<BountyHeading price={tokenValues?.total} bounty={bounty} />
+					{internalMenu == 'View' && <BountyCardDetails justMinted={justMinted} bounty={bounty} setInternalMenu={setInternalMenu} address={address} tokenValues={tokenValues} internalMenu={internalMenu} />}
 					{internalMenu == 'Fund' && bounty ? <FundPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
 					{internalMenu == 'Claim' && bounty ? <ClaimPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
 					{bounty && <RefundPage bounty={bounty} refreshBounty={refreshBounty} internalMenu={internalMenu} />}

--- a/pages/bounty/[id]/[address].js
+++ b/pages/bounty/[id]/[address].js
@@ -102,17 +102,18 @@ const address = ({ address, mergedBounty, renderError }) => {
 	};
 
 	useEffect(() => {
+		if(internalMenu){
+			sessionStorage.setItem(address, internalMenu);}
+	}, [internalMenu]);
+
+	// Hooks
+	useEffect(async() => {
 		const handleResize= ()=>{
 			if(canvas.current){
 				canvas.current.width = window.innerWidth;
 				canvas.current.height = window.innerHeight;}
 		};
 		window.addEventListener('resize', handleResize, false);
-		return ()=>window.removeEventListener('resize', handleResize);
-	}, []);
-
-	// Hooks
-	useEffect(async() => {
 		// Confetti
 		const justMinted = sessionStorage.getItem('justMinted') === 'true';
 		if (justMinted && canvas.current) {
@@ -142,6 +143,8 @@ const address = ({ address, mergedBounty, renderError }) => {
 				setInternalMenu(route || 'View');
 			}
 		}
+		
+		return ()=>window.removeEventListener('resize', handleResize);
 	}, []);
 
 
@@ -165,7 +168,7 @@ const address = ({ address, mergedBounty, renderError }) => {
 					<RepoTitle bounty={bounty} />
 					<SubMenu colour="rust" items={[{name: 'View', Svg: Telescope },{name: 'Fund', Svg: Add },{name: 'Refund', Svg: Subtract },{name: 'Claim', Svg: Fire },]} internalMenu={internalMenu} updatePage={setInternalMenu}/>
 					
-					<BountyHeading price={tokenValues?.total}  bounty={bounty} />
+					<BountyHeading price={tokenValues?.total} justMinted={!bounty.issuer} bounty={bounty} />
 					{internalMenu == 'View' && <BountyCardDetails bounty={bounty} setInternalMenu={setInternalMenu} address={address} tokenValues={tokenValues} internalMenu={internalMenu} />}
 					{internalMenu == 'Fund' && bounty ? <FundPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
 					{internalMenu == 'Claim' && bounty ? <ClaimPage bounty={bounty} refreshBounty={refreshBounty} /> : null}

--- a/services/SuperfluidClient/SuperfluidClient.js
+++ b/services/SuperfluidClient/SuperfluidClient.js
@@ -11,10 +11,11 @@ import { HttpLink, ApolloClient, InMemoryCache } from '@apollo/client';
 import fetch from 'cross-fetch';
 
 class SuperfluidClient {
-	httpLink = new HttpLink({ uri:'http://localhost:8020/subgraphs/name/superfluid-test/graphql', fetch });
+
+	httpLink = new HttpLink({ uri: process.env.NEXT_PUBLIC_SUPERFLUID_SUBGRAPH_HTTP_URL, fetch });
 
 	client = new ApolloClient({
-		uri: 'http://localhost:8020/subgraphs/name/superfluid-test/graphql',
+		uri: process.env.SUPERFLUID_SUBGRAPH_URL,
 
 		link: this.httpLink,
 		cache: new InMemoryCache(),

--- a/services/subgraph/graphql/query.js
+++ b/services/subgraph/graphql/query.js
@@ -62,17 +62,21 @@ query GetBounty($id: ID!) {
 		closer{
 		id
 		}
-		deposits {
+		deposits(orderBy: "receiveTime", orderDirection: "desc") {
       id
 			refunded
-			refundTime
+			receiveTime
       tokenAddress
 			expiration
       volume
       sender {
         id
       }
-      receiveTime
+    }
+		refunds(orderBy: "refundTime", orderDirection: "desc") {
+			refundTime
+      tokenAddress
+      volume
     }
 		bountyTokenBalances {
 		  tokenAddress

--- a/services/utils/Utils.js
+++ b/services/utils/Utils.js
@@ -15,7 +15,8 @@ class Utils {
 		// Hours part from the timestamp
 		var hours = date.getHours();
 		// Minutes part from the timestamp
-		var minutes = '0' + date.getMinutes();
+		var minutes =  date.getMinutes();
+		const displayMinutes =`${minutes.length===1 ? '0': ''}${minutes}`;
 		// Seconds part from the timestamp
 		var seconds = '0' + date.getSeconds();
 
@@ -23,7 +24,7 @@ class Utils {
 		if(hideDate){
 			return `${month} ${day}, ${year}`;
 		}
-		var formattedTime = `${month} ${day}, ${year}`;
+		var formattedTime = `${month} ${day}, ${year} at ${hours}:${displayMinutes}`;
 		return formattedTime;
 	};
 
@@ -55,7 +56,7 @@ class Utils {
 	};
 
 	formatDate = (createdAt, hideDate) => {
-		return this.formatUnixDate(new Date(createdAt), hideDate);
+		return this.formatUnixDate(new Date(createdAt)/1000, hideDate);
 	};
 
 	issurUrlRegex = (issueUrl) => {
@@ -115,6 +116,30 @@ class Utils {
 		}	);
 		return fullBounties;
 	}
+
+		mergeOrdered = (left, right, lProperty, rProperty)=>{
+			const mergedArr = [];		
+			let il= 0, ir =0, i =0;
+			while(il<left.length && ir <right.length ){
+				if(left[il][lProperty]> right[ir][rProperty]){
+					mergedArr[i++] = left[il++];
+				}
+				else{
+					mergedArr[i++] = right[ir++];
+				}
+			}
+			if(left[ir]){
+				while(il<left.length){
+					mergedArr[i++] = left[il++];
+				}
+			}
+			if(right[ir]){
+				while( right[ir][rProperty]){
+					mergedArr[i++] = right[ir++];		
+				}
+			}
+			return mergedArr;
+		};
 
 	capitalize = (word) =>{
 		return word[0].toUpperCase() + word.substring(1);


### PR DESCRIPTION
Closes #554  uses ens when on the timeline where possible. Please check this as I was only able to test it by messing with props. I still haven't gotten an ens name.
Closes #551 made mint bounty modal and view stream say Created on {{month}}, {{date}} at {{time}}.
Closes #550 fixed issues that occur when user is pushed to the issue directly after the graph indexes the bounty, including the bounty status. I wasn't noticing this on local because the local graph almost instantly indexes the new bounty.
Closes #549 dispatched the CONNECT_WALLET action instead of attempting star when user is disconnected.
Closes #547 Added target = "_blank" to github links.
MintBountyModal:
![image](https://user-images.githubusercontent.com/72156679/183119829-87d09f29-86b5-46c5-9990-f9ac7a3b04e2.png)


