### PR TITLE
Close Button, FundPage, ClaimPage, RefreshBounty(), AdminPage

### DIFF
--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -35,18 +35,19 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 			console.log({ message, title });
 		}
 	}
-
-	if (bounty.bountyType == '2') {
+	
+	if (bounty.bountyType == '2' && (ethers.utils.getAddress(bounty.issuer.id) == account)) {
 		return (
 			<>
 				<button
+					className="btn-default"
 					type="button"
 					onClick={closeCompetition}
 				>Close Competition</button>
 			</>
 		);
 	} else if (bounty.bountyType == '1' && (ethers.utils.getAddress(bounty.issuer.id) == account)) {
-		return ( 
+		return (
 			<>
 				<button
 					className="btn-default"

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -3,16 +3,27 @@ import React, { useState, useEffect, useContext } from 'react';
 import useWeb3 from '../../hooks/useWeb3';
 import StoreContext from '../../store/Store/StoreContext';
 import { ethers } from 'ethers';
+import TokenFundBox from '../FundBounty/SearchTokens/TokenFundBox';
 
 const AdminPage = ({ bounty, refreshBounty }) => {
 
 	// Context
 	const { library, account, } = useWeb3();
 	const [appState, dispatch] = useContext(StoreContext);
+	const zeroAddressMetadata = {
+		name: 'Matic',
+		address: '0x0000000000000000000000000000000000000000',
+		symbol: 'MATIC',
+		decimals: 18,
+		chainId: 80001,
+		path: 'https://wallet-asset.matic.network/img/tokens/matic.svg'
+	};
 
 	// State
 	const [error, setError] = useState('');
 	const [showButton, setShowButton] = useState(ethers.utils.getAddress(bounty.issuer.id) == account && !bounty.bountyClosedTime)
+	const [volume, setVolume] = useState('');
+	const [token, setToken] = useState(zeroAddressMetadata);
 
 	async function closeCompetition() {
 		try {
@@ -40,33 +51,78 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 		}
 	}
 
-	if (showButton) {
-		if (bounty.bountyType == '2') {
-			return (
-				<>
-					<button
-						className="btn-default"
-						type="button"
-						onClick={closeCompetition}
-					>Close Competition</button>
-				</>
-			);
-		} else if (bounty.bountyType == '1') {
-			return (
-				<>
-					<button
-						className="btn-default"
-						type="button"
-						onClick={closeOngoing}
-					>Close Ongoing Bounty</button>
-				</>
-			);
-		} else {
-			return null;
-		}
-	} else {
-		return null;
+	function onCurrencySelect(token) {
+		setToken({ ...token, address: ethers.utils.getAddress(token.address) });
 	}
+
+	function onVolumeChange(volume) {
+		appState.utils.updateVolume(volume, setVolume);
+	}
+
+	function setBudget() {
+		alert('please set this function to actually change Budget for this issue')
+	}
+
+	if (showButton) {
+		return (
+			<>
+				<div className="flex flex-1 flex-col space-y-8 sm:px-12 px-4 pt-4 pb-8 w-full max-w-[800px] justify-center">
+					<div className="flex flex-col space-y-2 items-center w-full md:border rounded-sm border-gray-700 text-primary pb-8">
+						<h1 className="flex w-full text-3xl justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm">
+							Settings
+						</h1>
+						<div className="flex flex-col space-y-5 w-full px-8 pt-2">
+							<h2 className='text-2xl border-b border-gray-700 pb-4'>Modifications</h2>
+							<div className='flex items-center gap-2'>Set a New Budget for this Contract</div>
+							<div className='flex-1 items-center w-full mt-2'>
+								<TokenFundBox
+									onCurrencySelect={onCurrencySelect}
+									onVolumeChange={onVolumeChange}
+									token={token}
+									volume={volume}
+								/>
+							</div>
+							<button
+								className="btn-default"
+								type="button"
+								onClick={setBudget}
+							>Set New Budget</button>
+							{bounty.bountyType == '2' ?
+								<>
+									<h2 className='text-2xl text-[#f85149] border-b border-gray-700 pb-4'>Close Contract</h2>
+									<div className='flex items-center gap-2'>Once you close the contract for this contest, there is no going back. Please be certain.
+									</div>
+									<button
+										className="btn-danger"
+										type="button"
+										onClick={closeCompetition}
+									>Close Competition</button>
+								</>
+
+								:
+								bounty.bountyType == '1' ?
+									<>
+										<h2 className='text-2xl text-[#f85149] border-b border-gray-700 pb-4'>Close Repeatable Contract</h2>
+										<div className='flex justify-between items-center gap-2'>Once you close this repeatable contract, there is no going back. Please be certain.
+										</div>
+										<button
+											className="btn-danger"
+											type="button"
+											onClick={closeOngoing}
+										>Close Repeatable Contract</button>
+									</>
+									:
+									null
+							}
+						</div>
+					</div>
+				</div>
+			</>)
+	} else {
+		return <></>;
+	}
+
+
 
 };
 

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -1,7 +1,6 @@
 // Third party Libraries
-import React, { useState, useRef, useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import useWeb3 from '../../hooks/useWeb3';
-import axios from 'axios';
 import StoreContext from '../../store/Store/StoreContext';
 import { ethers } from 'ethers';
 
@@ -13,10 +12,13 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 
 	// State
 	const [error, setError] = useState('');
+	const [showButton, setShowButton] = useState(ethers.utils.getAddress(bounty.issuer.id) == account && !bounty.bountyClosedTime)
 
 	async function closeCompetition() {
 		try {
 			await appState.openQClient.closeCompetition(library, bounty.bountyId);
+			setShowButton(false);
+			refreshBounty();
 		} catch (error) {
 			console.log(error);
 			const { message, title } = appState.openQClient.handleError(error, { bounty });
@@ -28,6 +30,8 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 	async function closeOngoing() {
 		try {
 			await appState.openQClient.closeOngoing(library, bounty.bountyId);
+			setShowButton(false);
+			refreshBounty();
 		} catch (error) {
 			console.log(error);
 			const { message, title } = appState.openQClient.handleError(error, { bounty });
@@ -35,30 +39,35 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 			console.log({ message, title });
 		}
 	}
-	
-	if (bounty.bountyType == '2' && (ethers.utils.getAddress(bounty.issuer.id) == account)) {
-		return (
-			<>
-				<button
-					className="btn-default"
-					type="button"
-					onClick={closeCompetition}
-				>Close Competition</button>
-			</>
-		);
-	} else if (bounty.bountyType == '1' && (ethers.utils.getAddress(bounty.issuer.id) == account)) {
-		return (
-			<>
-				<button
-					className="btn-default"
-					type="button"
-					onClick={closeOngoing}
-				>Close Ongoing Bounty</button>
-			</>
-		);
+
+	if (showButton) {
+		if (bounty.bountyType == '2') {
+			return (
+				<>
+					<button
+						className="btn-default"
+						type="button"
+						onClick={closeCompetition}
+					>Close Competition</button>
+				</>
+			);
+		} else if (bounty.bountyType == '1') {
+			return (
+				<>
+					<button
+						className="btn-default"
+						type="button"
+						onClick={closeOngoing}
+					>Close Ongoing Bounty</button>
+				</>
+			);
+		} else {
+			return null;
+		}
 	} else {
 		return null;
 	}
+
 };
 
 export default AdminPage;

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -19,8 +19,9 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 	//Render
 	return (
 		<div className="w-2/3 lg:w-1/2 pb-20">
+		{console.log(bounty)}
 			<div className="flex flex-col space-y-5">
-				<h2 className="flex text-3xl font-semibold  justify-center pt-16">Bounty Closed</h2>
+				<h2 className="flex text-3xl justify-center pt-16">Bounty Closed</h2>
 				<div className="flex justify-center rounded-sm px-6 py-4 pb-4 cursor-pointer" >			
 					<div className="my-2">Closing Transaction: <Link href={url}>
 						<a target={'_blank'} rel="noopener norefferer"  className="cursor-pointer break-all">

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -36,7 +36,7 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 	const [, dispatch] = useContext(StoreContext);
 
 
-	const claimed = bounty.status == 'CLOSED';
+	const claimable = (bounty.bountyType == 0 || bounty.bountyType == 1 || bounty.bountyType == 3) ? bounty.bountyClosedTime : !bounty.bountyClosedTime ;
 
 	const updateModal = () => {
 		setShowClaimLoadingModal(false);
@@ -108,11 +108,18 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 			});
 	};
 
-	if (claimed) {
+	if (claimable) {
 		return (
+			
+			bounty.bountyClosedTime ? 
+			// case where bounty is not claimable anymore (Atomic Contract and Repeatable Contract closed)
 			<BountyClosed bounty={bounty} showTweetLink={justClaimed} />
+			:
+			// case where bounty not claimable yet (contest not closed yet) 
+			<div className='text-lg'>Contest must be closed in order to be able to claime your rewards.</div>
 		);
 	} else {
+		// rewards are claimable
 		return (
 			<>
 				<div className="flex flex-1 px-12 pt-4 pb-8 w-full max-w-[1200px] justify-center">

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -203,7 +203,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
 			:
 			<div className="flex flex-1 sm:px-12 px-4 pt-4 pb-8 w-full max-w-[1200px] justify-center">
 				<div className="flex flex-col space-y-5 pb-4 items-center md:border rounded-sm border-gray-700">
-					<div className="flex text-3xl text-primary justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm">
+					<div className="flex text-3xl text-primary justify-center px-16 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm">
 						Escrow Funds in {bountyName}
 					</div>
 					<div className="flex flex-col space-y-5 w-5/6 pt-2">

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -200,6 +200,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
 				<div className="flex flex-col space-y-5 pb-4 items-center md:border rounded-sm border-gray-700">
 					<div className="flex text-3xl text-primary justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm">
 						Escrow Funds in Atomic Contract
+						{console.log(bounty)}
 					</div>
 					<div className="flex flex-col space-y-5 w-5/6 pt-2">
 						<TokenFundBox

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -45,9 +45,10 @@ const FundPage = ({ bounty, refreshBounty }) => {
 
 	// State
 	const [token, setToken] = useState(zeroAddressMetadata);
+	const bountyName = (bounty.bountyType == 0 || bounty.bountyType == 3) ? 'Atomic Contract' : bounty.bountyType == 1? 'Repeatable Contract' : 'Contest' ;
 
-	const claimed = bounty.status == 'CLOSED';
-	const loadingClosedOrZero = approveTransferState == CONFIRM || approveTransferState == APPROVING || approveTransferState == TRANSFERRING || claimed || parseFloat(volume) <= 0.00000001 || parseFloat(volume) >= 1000 || volume == '' || !(parseInt(depositPeriodDays) > 0);
+	const closed = bounty.bountyClosedTime;
+	const loadingClosedOrZero = approveTransferState == CONFIRM || approveTransferState == APPROVING || approveTransferState == TRANSFERRING || closed || parseFloat(volume) <= 0.00000001 || parseFloat(volume) >= 1000 || volume == '' || !(parseInt(depositPeriodDays) > 0);
 	const disableOrEnable = `${(loadingClosedOrZero || !isOnCorrectNetwork) && account ? 'btn-default w-full cursor-not-allowed' : 'btn-primary cursor-pointer'}`;
 	const fundButtonClasses = `flex flex-row w-full justify-center space-x-5 items-center  ${disableOrEnable}`;
 
@@ -194,13 +195,16 @@ const FundPage = ({ bounty, refreshBounty }) => {
 
 	// Render
 	return (<>
-		{claimed ?
-			<BountyClosed bounty={bounty} /> :
+		{closed ?
+			<>
+				<h1 className='text-3xl'>Cannot Fund a Closed {bountyName}!</h1>
+				<BountyClosed bounty={bounty} />
+			</>
+			:
 			<div className="flex flex-1 sm:px-12 px-4 pt-4 pb-8 w-full max-w-[1200px] justify-center">
 				<div className="flex flex-col space-y-5 pb-4 items-center md:border rounded-sm border-gray-700">
 					<div className="flex text-3xl text-primary justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm">
-						Escrow Funds in Atomic Contract
-						{console.log(bounty)}
+						Escrow Funds in {bountyName}
 					</div>
 					<div className="flex flex-col space-y-5 w-5/6 pt-2">
 						<TokenFundBox
@@ -212,7 +216,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
 
 						<div className="flex w-full input-field-big">
 							<div className=' flex items-center gap-3 w-full text-primary md:whitespace-nowrap'>
-								<ToolTipNew mobileX={10} toolTipText={'This is the number of days that your deposit will be in escrow. After this many days, you\'re deposit will be fully refundable if the bounty has still not been claimed.'} >
+								<ToolTipNew toolTipText={'This is the number of days that your deposit will be in escrow. After this many days, your deposit will be fully refundable if the bounty has still not been claimed.'} >
 									<div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>?</div>
 								</ToolTipNew>
 								<span>Deposit Locked Period</span>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -199,10 +199,10 @@ const MintBountyModal = ({ modalVisibility, type }) => {
 					error={error}
 				/> :
 				<>
-					<div ref={modal} className="m-auto w-3/5 min-w-[320px] z-50 fixed top-10">
+					<div ref={modal} className="m-auto w-3/5 min-w-[320px] z-50 fixed top-28">
 						<div className="w-full rounded-sm flex flex-col bg-[#161B22] z-11 space-y-1">
 							<SubMenu items={[{ name: 'Single' }, { name: 'Atomic' }, { name: 'Ongoing' }, { name: 'Tiered' }]} internalMenu={toggleType} updatePage={setToggleType} styles={'justify-center'}/>
-							<div className='max-h-[80vh] w-full overflow-y-auto'>
+							<div className='max-h-[70vh] w-full overflow-y-auto'>
 								<MintBountyHeader type={toggleType} />
 								<div className="flex flex-col items-center pl-6 pr-6">
 									<MintBountyInput

--- a/pages/bounty/[id]/[address].js
+++ b/pages/bounty/[id]/[address].js
@@ -113,7 +113,6 @@ const address = ({ address, mergedBounty, renderError }) => {
 
 	useEffect(()=> {
 		setInternalMenu('View')
-		console.log("account changes: ", account)
 	}, [account]);
 
 	// Hooks

--- a/pages/bounty/[id]/[address].js
+++ b/pages/bounty/[id]/[address].js
@@ -90,6 +90,7 @@ const address = ({ address, mergedBounty, renderError }) => {
 			const refundedNow = refundCount(newBounty.deposits);
 			while (newBounty.deposits.length === bounty.deposits.length && newBounty.status === bounty.status && refundedBefore === refundedNow
 				&& expirationComp(bounty.deposits, newBounty.deposits)
+				&& newBounty.bountyClosedTime === bounty.bountyClosedTime
 				// or simpler, just using: && newBounty.deposits === bounty.deposits
 				// in which case we could also be removing the 'newBounty.deposits.length === bounty.deposits.length' logic and simplify
 			) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -103,6 +103,9 @@ pre {
 	.btn-default{
 		@apply rounded-sm px-3 p-1 bg-[#21262d] hover:bg-[#30363d] border border-gray-700 hover:border-[#8b949e]
 	}
+	.btn-danger{
+		@apply text-[#f85149] hover:text-white rounded-sm px-3 p-1 bg-[#21262d] hover:bg-[#da3633] active:bg-[#b62324] border border-[rgba(240,246,252,0.1)] hover:border-[#f85149] active:border-[#ff7b72]
+	}
 	.btn-card{
 		@apply bg-inactive-gray py-1 px-2 border-web-gray border rounded-sm text-xs text-primary
 	}


### PR DESCRIPTION
closes #558, closes #571, improves #557 and adapts ClaimPage

Note: it might be time to see whether PR #470 is OK as I've added yet another line to Refreshbounty() (see below)

- Close button doesn't show if not issuer (both Competition and Ongoing) or if already closed
- MintBountyModal more centered (fixed to top but lower)
- Funding not possible if bounty closed/claimed (covers all types)
- Refreshbounty() now also reacts when bountyClosedTime changes
- ClaimPage logic adapted: 
=> not claimable when contest still open with message that contest needs to be finished first
=> vs. not claimable when atomic/ongoing closed with BountyClosed component
- AdminPage redesign according to GitHub Settings + adding setter for funding goal/budget (no logic relating to smart contract yet)