### PR TITLE
Staging newcontracts

### DIFF
--- a/components/BountyCard/BountyModalHeading.js
+++ b/components/BountyCard/BountyModalHeading.js
@@ -15,9 +15,15 @@ const BountyModalHeading = ({bounty, closeModal, unWatchable})=>{
 	const [watchingDisplay, setWatchingDisplay] = useState();
 	const { safe } = useWeb3();
 	
-	useEffect(() => {
-		const watching = bounty?.watchingUserIds?.some(user => user === account);
-		setWatchingDisplay(watching);
+	useEffect(async() => {
+		if(account){
+			const user = await appState.openQPrismaClient.getUser(account);
+			if(user){
+
+				const watching = user.watchedBountyIds?.some(bountyAddress => bountyAddress === bounty.address);
+				setWatchingDisplay(watching);
+			}
+		}
 	}, [account]);
 
 	const signMessage = async () => {
@@ -52,23 +58,30 @@ const BountyModalHeading = ({bounty, closeModal, unWatchable})=>{
 			}
 
 
+			const payload = {
+				type: 'RELOAD_NOW',
+				payload: Date.now()
+			};
 			setWatchDisabled(true);
 			if (watchingDisplay) {
-				await appState.openQPrismaClient.unWatchBounty(ethers.utils.getAddress(bounty.bountyAddress), account);
+				console.log('exec');
+				const result = await appState.openQPrismaClient.unWatchBounty(ethers.utils.getAddress(bounty.bountyAddress), account);
+				console.log(result);
 				setWatchingDisplay(false);
+				if(result){
+					dispatch(payload);
+				}
 				setWatchDisabled(false);
 			} else {
-				await appState.openQPrismaClient.watchBounty(ethers.utils.getAddress(bounty.bountyAddress), account);
+				console.log('exic');
+				const result = await appState.openQPrismaClient.watchBounty(ethers.utils.getAddress(bounty.bountyAddress), account);
+				if(result){
+					dispatch(payload);
+				}
 				setWatchingDisplay(true);
 				setWatchDisabled(false);
 			}
 
-			const payload = {
-				type: 'UPDATE_RELOAD',
-				payload: true
-			};
-
-			dispatch(payload);
 		} catch (error) {
 			console.error(error);
 		}

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -34,8 +34,19 @@ const Navigation = () => {
 		setOpenMenu(false);
 	}, [router.asPath]);
 
-	useEffect(async()=>{
-	},[]);
+	useEffect(async()=>{	
+		if(account){
+			const response = await axios.get(`${process.env.NEXT_PUBLIC_AUTH_URL}/hasSignature?address=${account}`, { withCredentials: true });
+			if (response.data.status===false) {
+				await axios.post(`${process.env.NEXT_PUBLIC_AUTH_URL}/verifySignature`,
+					{
+						signature: '',
+						address: account
+					}, { withCredentials: true }
+				);
+			}	
+		}
+	},[account]);
 
 	useEffect(async () => {
 	// set up searchable

--- a/pages/[type].js
+++ b/pages/[type].js
@@ -41,10 +41,7 @@ export default function Index({ orgs, fullBounties, batch, types, renderError })
 			const [mergedOrgs] = await appState.utils.fetchOrganizations(appState, types);
 			setControlledOrgs(mergedOrgs);
 			// get watched bounties when reload action is triggered.
-			if (account) {
-				const [watchedBounties ]= await appState.utils.fetchWatchedBounties(appState, account, types);
-				setWatchedBounties(watchedBounties);
-			}
+		
 		}
 
 	},[reloadNow]);
@@ -53,7 +50,7 @@ export default function Index({ orgs, fullBounties, batch, types, renderError })
 		// get watched bounties as soon as we know what the account is.
 		if (account) {
 			const [watchedBounties ]= await appState.utils.fetchWatchedBounties(appState,account, types);
-			setWatchedBounties(watchedBounties);
+			setWatchedBounties(watchedBounties||[]);
 		}
 
 	}, [account, reloadNow]);

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,22 +29,12 @@ export default function Index({  fullBounties, batch, types, renderError }) {
 	const { account } = useWeb3();
 
 	// Hooks
-	useEffect(async()=>{
-		if(reloadNow){		
-			// get watched bounties when reload action is triggered.
-			if (account) {
-				const [watchedBounties ]= await appState.utils.fetchWatchedBounties(appState,account, types);
-				setWatchedBounties(watchedBounties);
-			}
-		}
-
-	},[reloadNow]);
 
 	useEffect(async () => {
 		// get watched bounties as soon as we know what the account is.
 		if (account) {
 			const [watchedBounties ]= await appState.utils.fetchWatchedBounties(appState,account, types);
-			setWatchedBounties(watchedBounties);
+			setWatchedBounties(watchedBounties||[]);
 		}
 
 	}, [account, reloadNow]);

--- a/services/openq-api/OpenQPrismaClient.js
+++ b/services/openq-api/OpenQPrismaClient.js
@@ -20,9 +20,10 @@ class OpenQPrismaClient {
 			try {
 				const result = await this.client.mutate({
 					mutation: WATCH_BOUNTY,
-					variables: { contractAddress, userAddress }
+					variables: { contractAddress, userAddress },
+					fetchPolicy: 'no-cache'
 				});
-				resolve(result.data.organization);
+				resolve(result.data);
 			} catch (e) {
 				reject(e);
 			}
@@ -35,9 +36,10 @@ class OpenQPrismaClient {
 			try {
 				const result = await this.client.mutate({
 					mutation: UNWATCH_BOUNTY,
-					variables: { contractAddress, userAddress }
+					variables: { contractAddress, userAddress },
+					fetchPolicy: 'no-cache'
 				});
-				resolve(result.data.organization);
+				resolve(result.data);
 			} catch (e) {
 				reject(e);
 			}
@@ -224,8 +226,8 @@ class OpenQPrismaClient {
 	async getUser(userAddress) {
 		const promise = new Promise(async (resolve, reject) => {
 			try {
-				const result = await this.client.query({
-					query: GET_USER_BY_HASH,
+				const result = await this.client.mutate({
+					mutation: GET_USER_BY_HASH,
 					variables: { userAddress: ethers.utils.getAddress(userAddress) }
 				});
 				resolve(result.data.user);

--- a/services/openq-api/graphql/query.js
+++ b/services/openq-api/graphql/query.js
@@ -66,7 +66,7 @@ query getBounties($addresses: [String]!){
   bounties(addresses:$addresses){
     blacklisted
 		tvl
-		watchingUserIds
+		
     address
   }
 }`;


### PR DESCRIPTION
Requires [https://github.com/OpenQDev/OpenQ-API/pull/16](https://github.com/OpenQDev/OpenQ-API/pull/16) and [https://github.com/OpenQDev/OpenQ-Github-OAuth-Server/pull/2](https://github.com/OpenQDev/OpenQ-Github-OAuth-Server/pull/2)
Revokes signature cookie when user switches to another account. Should I move this logic to the useAuth hook?
Refactors watched bounty fetching to fetch all watched bounty information by user.
Also uses .mutate to refetch watched bounty information when user watches a bounty or changes an account. Let me know if I should look into something better. Its been working without issues for fetching more starred orgs when the user stars them so far.

