### PR TITLE
SetPayoutSchedule, BountyClosed, Invoiceable & other

### DIFF
--- a/components/Admin/AdminModal.js
+++ b/components/Admin/AdminModal.js
@@ -113,7 +113,7 @@ const AdminModal = ({ setModal, modal }) => {
 										<div className='text-xs font-semibold leading-loose'>Number of tiers: </div>
 										<div className='text-xs font-semibold'>{modal.finalTierVolume.length}</div>
 									</div>
-									<div className='flex flex-col '>
+									<div className='flex flex-col max-h-40 w-full overflow-y-auto overflow-x-hidden'>
 										{modal.finalTierVolume.map((t, index) => {
 											return (
 												<div key={index} className='flex items-center gap-4 text-primary'>

--- a/components/Admin/AdminModal.js
+++ b/components/Admin/AdminModal.js
@@ -11,7 +11,7 @@ const AdminModal = ({setModal, modal})=>{
 
 	useEffect(()=>{
 	
-		if(modal.transaction){
+		if(modal.transaction && (modal.type === 'Budget' || modal.type === 'Payout')){
 			const tokenAddress = modal.transaction.events[0].args[1];
 			const token = appState.tokenClient.getToken(tokenAddress);
 			setToken(token);
@@ -49,6 +49,7 @@ const AdminModal = ({setModal, modal})=>{
 		['Closed Repeatable']: 'Repeatable Contract Closed!',
 		Budget:'Budget Updated!',
 		Payout: 'Payout Updated!',
+		PayoutSchedule: 'Payout Schedule Updated!',
 		Error: modal.title
 
 	};
@@ -56,6 +57,8 @@ const AdminModal = ({setModal, modal})=>{
 		['Closed Repeatable']: 'Repeatable contract closed, no further claims will be available through this contract. Check out the closing transaction with the link below:',
 		['Closed Contest']: 'Contest closed, now contestants can cash out. Check out the closing transaction with the link below:',
 		Budget: 'Budget has been updated. Check out your transaction with the link below:',
+		Payout: 'Payout has been updated. Check out your transaction with the link below:',
+		PayoutSchedule: 'Payout Schedule has been updated. Check out your transaction with the link below:',
 		Error: modal.message
 	};
 
@@ -64,7 +67,7 @@ const AdminModal = ({setModal, modal})=>{
 			<div  className="justify-center bg-overlay items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
 				<div ref={modalRef} className="min-w-[260px] max-w-[450px] mx-8 px-4 rounded-sm p-6 shadow-lg flex flex-col w-full bg-[#161B22] outline-none focus:outline-none">
 					
-					{(modal.type === 'Payout'||modal.type==='Budget' )&& token &&
+					{(modal.type === 'Payout'|| modal.type==='Budget') && token &&
 				<>
 					<h2 className='text-2xl font-semibold pb-8 self-center'>{title[modal.type]}</h2>
 					<p className='pb-4'>{content[modal.type]}</p>
@@ -86,6 +89,27 @@ const AdminModal = ({setModal, modal})=>{
 					</div>
 				</>					
 					}
+
+					
+					{modal.type === 'PayoutSchedule' && <>
+					<h2 className='text-2xl font-semibold pb-8 self-center'>{title[modal.type]}</h2>
+					<p className='pb-4'>{content[modal.type]}</p>
+					<div className='flex justify-between w-full gap-2 pb-4'>
+						<div className='w-28 flex-1'>Payout Schedule set to</div>
+						<div className='flex flex-wrap flex-1 justify-start w-[120px] gap-8'>
+							TIERS
+						</div>
+					</div>
+					<div className='flex justify-between pb-4'>
+						<div className='flex-1' href={modal.transaction.transactionHash}>Transaction: </div>
+						<a className='break-all flex-1 underline cursor-pointer' target="_blank" rel="noopener noreferrer" href={`${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/${modal.transaction.transactionHash}`}>
+							{modal.transaction.transactionHash.slice(0, 3)}...{modal.transaction.transactionHash.slice(-3)}
+							<svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+								<path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+							</svg>
+						</a>
+					</div>
+					</>}
 					
 					{(modal.type.includes('Closed')||modal.type==='Error')&&
 				<>

--- a/components/Admin/AdminModal.js
+++ b/components/Admin/AdminModal.js
@@ -1,27 +1,32 @@
-import React, {useContext, useEffect, useRef, useState} from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import StoreContext from '../../store/Store/StoreContext';
 import { ethers } from 'ethers';
 
 
-const AdminModal = ({setModal, modal})=>{
+const AdminModal = ({ setModal, modal }) => {
 	const [token, setToken] = useState();
 	const [volume, setVolume] = useState();
-	const [appState ] = useContext(StoreContext);
+	const [appState] = useContext(StoreContext);
 
-	useEffect(()=>{
-	
-		if(modal.transaction && (modal.type === 'Budget' || modal.type === 'Payout')){
+	useEffect(() => {
+
+		if (modal.transaction && (modal.type === 'Budget' || modal.type === 'Payout')) {
 			const tokenAddress = modal.transaction.events[0].args[1];
 			const token = appState.tokenClient.getToken(tokenAddress);
 			setToken(token);
-			const volume =  modal.transaction.events[0].args[2];
+			const volume = modal.transaction.events[0].args[2];
 			let bigNumberVolume = ethers.BigNumber.from(volume.toString());
-			let decimals = parseInt(token.decimals)||18;
+			let decimals = parseInt(token.decimals) || 18;
 			let formattedVolume = ethers.utils.formatUnits(bigNumberVolume, decimals);
-			setVolume(formattedVolume);			
+			setVolume(formattedVolume);
 		}
-	},[]);
+
+		if (modal.transaction && (modal.type === 'PayoutSchedule')) {
+
+		}
+
+	}, []);
 
 	const modalRef = useRef();
 	useEffect(() => {
@@ -34,20 +39,20 @@ const AdminModal = ({setModal, modal})=>{
 
 		// Bind the event listener
 		document.addEventListener('mousedown', handleClickOutside);
-		
+
 		return () => {
 			// Unbind the event listener on clean up
 			document.removeEventListener('mousedown', handleClickOutside);
 		};
 	}, [modal, modalRef]);
 
-	const closeModal = ()=>{
+	const closeModal = () => {
 		setModal(false);
 	};
-	const title={
+	const title = {
 		['Closed Contest']: 'Contest Closed!',
 		['Closed Repeatable']: 'Repeatable Contract Closed!',
-		Budget:'Budget Updated!',
+		Budget: 'Budget Updated!',
 		Payout: 'Payout Updated!',
 		PayoutSchedule: 'Payout Schedule Updated!',
 		Error: modal.title
@@ -62,63 +67,85 @@ const AdminModal = ({setModal, modal})=>{
 		Error: modal.message
 	};
 
+	function handleSuffix(t) {
+		const s = ['th', 'st', 'nd', 'rd'];
+		const v = t % 100;
+		return (t + (s[(v - 20) % 10] || s[v] || s[0]));
+	}
+
 	return (
 		<div>
-			<div  className="justify-center bg-overlay items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
+			<div className="justify-center bg-overlay items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
 				<div ref={modalRef} className="min-w-[260px] max-w-[450px] mx-8 px-4 rounded-sm p-6 shadow-lg flex flex-col w-full bg-[#161B22] outline-none focus:outline-none">
-					
-					{(modal.type === 'Payout'|| modal.type==='Budget') && token &&
-				<>
-					<h2 className='text-2xl font-semibold pb-8 self-center'>{title[modal.type]}</h2>
-					<p className='pb-4'>{content[modal.type]}</p>
-					<div className='flex justify-between w-full gap-2 pb-4'>
-						<div className='w-28 flex-1'>Payout set to</div>
-						<div className='flex flex-wrap flex-1 justify-start w-[120px] gap-8'>
-							<Image width={24} className="inline" height={24} src={token.path || token.logoURI || '/crypto-logos/ERC20.svg'} />
-							<span>{volume} {token.symbol}</span>
-						</div>
-					</div>
-					<div className='flex justify-between pb-4'>
-						<div className='flex-1' href={modal.transaction.transactionHash}>Transaction: </div>
-						<a className='break-all flex-1 underline cursor-pointer' target="_blank" rel="noopener noreferrer" href={`${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/${modal.transaction.transactionHash}`}>
-							{modal.transaction.transactionHash.slice(0, 3)}...{modal.transaction.transactionHash.slice(-3)}
-							<svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-								<path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-							</svg>
-						</a>
-					</div>
-				</>					
+
+					{(modal.type === 'Payout' || modal.type === 'Budget') && token &&
+						<>
+							<h2 className='text-2xl font-semibold pb-8 self-center'>{title[modal.type]}</h2>
+							<p className='pb-4'>{content[modal.type]}</p>
+							<div className='flex justify-between w-full gap-2 pb-4'>
+								<div className='w-28 flex-1'>Payout set to</div>
+								<div className='flex flex-wrap flex-1 justify-start w-[120px] gap-8'>
+									<Image width={24} className="inline" height={24} src={token.path || token.logoURI || '/crypto-logos/ERC20.svg'} />
+									<span>{volume} {token.symbol}</span>
+								</div>
+							</div>
+							<div className='flex justify-between pb-4'>
+								<div className='flex-1' href={modal.transaction.transactionHash}>Transaction: </div>
+								<a className='break-all flex-1 underline cursor-pointer' target="_blank" rel="noopener noreferrer" href={`${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/${modal.transaction.transactionHash}`}>
+									{modal.transaction.transactionHash.slice(0, 3)}...{modal.transaction.transactionHash.slice(-3)}
+									<svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+										<path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+									</svg>
+								</a>
+							</div>
+						</>
 					}
 
-					
-					{modal.type === 'PayoutSchedule' && <>
-					<h2 className='text-2xl font-semibold pb-8 self-center'>{title[modal.type]}</h2>
-					<p className='pb-4'>{content[modal.type]}</p>
-					<div className='flex justify-between w-full gap-2 pb-4'>
-						<div className='w-28 flex-1'>Payout Schedule set to</div>
-						<div className='flex flex-wrap flex-1 justify-start w-[120px] gap-8'>
-							TIERS
-						</div>
-					</div>
-					<div className='flex justify-between pb-4'>
-						<div className='flex-1' href={modal.transaction.transactionHash}>Transaction: </div>
-						<a className='break-all flex-1 underline cursor-pointer' target="_blank" rel="noopener noreferrer" href={`${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/${modal.transaction.transactionHash}`}>
-							{modal.transaction.transactionHash.slice(0, 3)}...{modal.transaction.transactionHash.slice(-3)}
-							<svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-								<path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-							</svg>
-						</a>
-					</div>
-					</>}
-					
-					{(modal.type.includes('Closed')||modal.type==='Error')&&
-				<>
-					<h2 className='text-2xl font-semibold pb-6 self-center'>{title[modal.type]}</h2>
-					<p>{content[modal.type]}</p>
-					{modal.type !== 'Error' && <a className='break-all underline cursor-pointer'> {process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/{modal.transaction.transactionHash}</a>}
-				</>					
+
+					{modal.type === 'PayoutSchedule' &&
+						<>
+							<h2 className='text-2xl font-semibold pb-8 self-center'>{title[modal.type]}</h2>
+							<p className='pb-4'>{content[modal.type]}</p>
+							<div className='flex justify-between w-full gap-2 pb-4'>
+								<div className='w-28 flex-1'>Payout Schedule set to</div>
+								<div className='flex flex-wrap flex-1 justify-start w-[120px] '>
+									<div className='flex items-center gap-4 pt-2 text-primary'>
+										<div className='text-xs font-semibold leading-loose'>Number of tiers: </div>
+										<div className='text-xs font-semibold'>{modal.finalTierVolume.length}</div>
+									</div>
+									<div className='flex flex-col '>
+										{modal.finalTierVolume.map((t, index) => {
+											return (
+												<div key={index} className='flex items-center gap-4 text-primary'>
+													<div className='text-xs font-semibold leading-loose'>{`${handleSuffix(index + 1)} winner:`}</div>
+													<div className='text-xs font-semibold' >{t} %</div>
+												</div>
+											)
+										})
+
+										}
+									</div>
+								</div>
+							</div>
+							<div className='flex justify-between pb-4'>
+								<div className='flex-1' href={modal.transaction.transactionHash}>Transaction: </div>
+								<a className='break-all flex-1 underline cursor-pointer' target="_blank" rel="noopener noreferrer" href={`${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/${modal.transaction.transactionHash}`}>
+									{modal.transaction.transactionHash.slice(0, 3)}...{modal.transaction.transactionHash.slice(-3)}
+									<svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+										<path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+									</svg>
+								</a>
+							</div>
+						</>}
+
+					{(modal.type.includes('Closed') || modal.type === 'Error') &&
+						<>
+							<h2 className='text-2xl font-semibold pb-6 self-center'>{title[modal.type]}</h2>
+							<p>{content[modal.type]}</p>
+							{modal.type !== 'Error' && <a className='break-all underline cursor-pointer'> {process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/{modal.transaction.transactionHash}</a>}
+						</>
 					}
-					
+
 					<button onClick={closeModal} className="btn-default py-1.5 mt-6 text-center flex justify-center cursor-pointer w-full"><span>Close</span></button>
 				</div>
 			</div>

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -363,7 +363,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 									<div className='text-xs font-semibold leading-loose'>Number of tiers: </div>
 									<div className='text-xs font-semibold'>{bounty.payoutSchedule.length}</div>
 								</div>
-								<div className='flex flex-col '>
+								<div className='flex flex-col max-h-80 w-full overflow-y-auto overflow-x-hidden'>
 									{bounty.payoutSchedule.map((t, index) => {
 										return (
 											<div key={index} className='flex items-center gap-4 text-primary'>

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -46,7 +46,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 	const [tokenValues] = useGetTokenValues(bounty.bountyTokenBalances, bounty);
 	const budgetBalances = [{"tokenAddress": bounty.fundingGoalTokenAddress, "volume": bounty.fundingGoalVolume}]
 	const [budgetValues] = useGetTokenValues(budgetBalances, bounty);
-	const splitBalances = [{"tokenAddress": bounty.payoutTokenAddress, "volume": bounty.payoutTokenVolume}]
+	const splitBalances = bounty.bountyType == 1? [{"tokenAddress": bounty.payoutTokenAddress, "volume": bounty.payoutTokenVolume}] : null;
 	const [splitValues] = useGetTokenValues(splitBalances, bounty);
 
 	// funding goal volume and token

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -156,8 +156,18 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 		}
 	}
 
-	async function setContestPayout() {
-		alert('link this to smart contract when available')
+	async function setPayoutSchedule() {
+		try {
+			setIsLoading(true);
+			const transaction = await appState.openQClient.setPayoutSchedule(library, bounty.bountyId, finalTierVolume);
+			refreshBounty();
+			// setPayoutVolume(''); // ?
+			setModal({ transaction, type: 'Payout' });
+		} catch (error) {
+			console.log(error);
+			const { message, title } = appState.openQClient.handleError(error, { bounty });
+			setError({ message, title });
+		}
 	}
 
 	async function closeCompetition() {
@@ -278,7 +288,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 										<button
 											className={`w-full btn-default ${enableContest ? 'cursor-pointer' : 'cursor-not-allowed'}`}
 											type="button"
-											onClick={setContestPayout}
+											onClick={setPayoutSchedule}
 											disabled={!enableContest}
 										>Set New Payout Schedule</button>
 									</ToolTipNew>

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -162,7 +162,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 			const transaction = await appState.openQClient.setPayoutSchedule(library, bounty.bountyId, finalTierVolume);
 			refreshBounty();
 			// setPayoutVolume(''); // ?
-			setModal({ transaction, type: 'PayoutSchedule' });
+			setModal({ transaction, type: 'PayoutSchedule', finalTierVolume: finalTierVolume });
 		} catch (error) {
 			console.log(error);
 			const { message, title } = appState.openQClient.handleError(error, { bounty });

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -162,7 +162,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
 			const transaction = await appState.openQClient.setPayoutSchedule(library, bounty.bountyId, finalTierVolume);
 			refreshBounty();
 			// setPayoutVolume(''); // ?
-			setModal({ transaction, type: 'Payout' });
+			setModal({ transaction, type: 'PayoutSchedule' });
 		} catch (error) {
 			console.log(error);
 			const { message, title } = appState.openQClient.handleError(error, { bounty });

--- a/components/BountyCard/BountyCardLean.js
+++ b/components/BountyCard/BountyCardLean.js
@@ -144,15 +144,23 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 							}
 							</div>
 							<div className='flex gap-4 content-center items-center justify-between sm:w-60'>
-								{bounty.bountyType === '0' ? <span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
-									<div className='whitespace-nowrap'>Single</div><PersonIcon />
-								</span> :
+								{bounty.bountyType === '0' ?
+									<span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
+										<div className='whitespace-nowrap'>Single</div>
+										<PersonIcon />
+									</span> :
 									bounty.bountyType === '1' ?
 
-										<div>	<div className='whitespace-nowrap'>Multi</div><PersonAddIcon /></div> :
+										<span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
+											<div className='whitespace-nowrap'>Multi</div>
+											<PersonAddIcon />
+										</span> :
 
 										bounty.bountyType === '2' &&
-										<div>	<div className='whitespace-nowrap'>Weighted</div><PeopleIcon /></div>
+										<span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
+											<div className='whitespace-nowrap'>Weighted</div>
+											<PeopleIcon />
+										</span>
 
 								}
 

--- a/components/BountyCard/BountyCardLean.js
+++ b/components/BountyCard/BountyCardLean.js
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Skeleton from 'react-loading-skeleton';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
 import BountyCardDetailsModal from './BountyCardDetailsModal';
+import ToolTipNew from '../Utils/ToolTipNew';
 import { PersonAddIcon, PersonIcon, PeopleIcon } from '@primer/octicons-react';
 
 
@@ -20,11 +21,11 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 	const [isModal, setIsModal] = useState();
 	const [payoutValues] = useGetTokenValues(bounty.payouts);
 	const [refundValues] = useGetTokenValues(bounty.refunds);
-	const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances );
-	
-	
-	const createBudget = (bounty)=>{
-		return  bounty.fundingGoalTokenAddress ? {tokenAddress: bounty.fundingGoalTokenAddress, volume: bounty.fundingGoalVolume}: null;
+	const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances);
+
+
+	const createBudget = (bounty) => {
+		return bounty.fundingGoalTokenAddress ? { tokenAddress: bounty.fundingGoalTokenAddress, volume: bounty.fundingGoalVolume } : null;
 	};
 	const budgetObj = useMemo(() => createBudget(bounty), [
 		bounty
@@ -36,11 +37,11 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 	const tokenTotal = tokenValues?.total;
 	const payoutTotal = payoutValues?.total;
 	const refundTotal = refundValues?.total;
-	const price=tokenTotal - payoutTotal - refundTotal;
+	const price = tokenTotal - payoutTotal - refundTotal;
 	// Hooks
 
 	const [authState] = useAuth();
-	const	marker = appState.utils.getBountyMarker(bounty, authState.login);
+	const marker = appState.utils.getBountyMarker(bounty, authState.login);
 
 	const TVL = price || price === 0
 		? appState.utils.formatter.format(price)
@@ -48,11 +49,11 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 	const closeModal = () => {
 		setIsModal(false);
 		document.body.style.height = 'auto';
-		document.body.style.overflowY = 'auto';		
+		document.body.style.overflowY = 'auto';
 	};
 	const openModal = () => {
 		document.body.style.height = '100vh';
-		document.body.style.overflowY = 'hidden';		
+		document.body.style.overflowY = 'hidden';
 		setIsModal(true);
 	};
 
@@ -62,7 +63,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 			<BountyCardDetailsModal unWatchable={unWatchable} TVL={TVL} bounty={bounty} closeModal={closeModal} showModal={isModal && bounty} price={price} />
 			<div onClick={openModal}
 				className={
-					`flex flex-col  md:px-4 py-4 border-web-gray cursor-pointer ${index!==length-1 && 'border-b'}`
+					`flex flex-col  md:px-4 py-4 border-web-gray cursor-pointer ${index !== length - 1 && 'border-b'}`
 				}
 			>
 				<div className="flex flex-row flex-wrap sm:flex-nowrap justify-between sm:pt-0 text-primary">
@@ -85,7 +86,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 							</div>
 							<div data-testid="title" className="break-word text-xl text-link-colour inline gap-1 pb-1">
 								<span>
-									{	bounty.owner && `${bounty.owner.toLowerCase()}/${bounty.repoName.toLowerCase()}`}
+									{bounty.owner && `${bounty.owner.toLowerCase()}/${bounty.repoName.toLowerCase()}`}
 								</span>
 								<span >
 								</span>
@@ -98,7 +99,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 									? bounty?.title.toLowerCase()
 									: bountyName.slice(0, 50) + '...'}
 						</div>
-						
+
 						<div className="flex flex-row items-center space-x-4 w-full">
 							<div className="font-light text-sm w-full">
 
@@ -107,27 +108,27 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 									`Deployed: ${appState.utils.formatUnixDate(parseInt(bounty?.bountyMintTime))}`
 								}
 							</div>
-							
-							
+
+
 						</div>
-						<LabelsList bounty={bounty}/>
+						<LabelsList bounty={bounty} />
 						<div className="flex flex-row items-center gap-4 text-muted font-semibold">
-							<span><svg xmlns="http://www.w3.org/2000/svg" 
+							<span><svg xmlns="http://www.w3.org/2000/svg"
 								className={'stroke-muted inline-block mr-1 -mt-1 fill-muted'} viewBox="0 0 16 16" width="16" height="16"><path d="M1.679 7.932c.412-.621 1.242-1.75 2.366-2.717C5.175 4.242 6.527 3.5 8 3.5c1.473 0 2.824.742 3.955 1.715 1.124.967 1.954 2.096 2.366 2.717a.119.119 0 010 .136c-.412.621-1.242 1.75-2.366 2.717C10.825 11.758 9.473 12.5 8 12.5c-1.473 0-2.824-.742-3.955-1.715C2.92 9.818 2.09 8.69 1.679 8.068a.119.119 0 010-.136zM8 2c-1.981 0-3.67.992-4.933 2.078C1.797 5.169.88 6.423.43 7.1a1.619 1.619 0 000 1.798c.45.678 1.367 1.932 2.637 3.024C4.329 13.008 6.019 14 8 14c1.981 0 3.67-.992 4.933-2.078 1.27-1.091 2.187-2.345 2.637-3.023a1.619 1.619 0 000-1.798c-.45-.678-1.367-1.932-2.637-3.023C11.671 2.992 9.981 2 8 2zm0 8a2 2 0 100-4 2 2 0 000 4z">
 								</path>
-							</svg>	
-							<span>{0}
-							</span></span>
-							
+							</svg>
+								<span>{0}
+								</span></span>
 
-							<span>Assigned to {bounty.assignees[0]?.name|| 'no one.'}</span>
-							{bounty.assignees[0]?.avatarUrl &&	<Image height={24} width={24} className='rounded-full pt-1' src={bounty.assignees[0]?.avatarUrl}/>}
+
+							<span>Assigned to {bounty.assignees[0]?.name || 'no one.'}</span>
+							{bounty.assignees[0]?.avatarUrl && <Image height={24} width={24} className='rounded-full pt-1' src={bounty.assignees[0]?.avatarUrl} />}
 						</div>
-						
+
 					</div>
-			
-			
-				
+
+
+
 
 					{loading ?
 						<Skeleton width={60} /> :
@@ -142,16 +143,16 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 								<Skeleton width={51} height={51} />
 							}
 							</div>
-							<div className='flex gap-4 content-center items-center sm:w-60'>
-								{bounty.bountyType=== '0' ?<span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
+							<div className='flex gap-4 content-center items-center justify-between sm:w-60'>
+								{bounty.bountyType === '0' ? <span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
 									<div className='whitespace-nowrap'>Single</div><PersonIcon />
-								</span>:
+								</span> :
 									bounty.bountyType === '1' ?
-								
-										<div>	<div className='whitespace-nowrap'>Multi</div><PersonAddIcon /></div>:
-									
+
+										<div>	<div className='whitespace-nowrap'>Multi</div><PersonAddIcon /></div> :
+
 										bounty.bountyType === '2' &&
-								<div>	<div className='whitespace-nowrap'>Weighted</div><PeopleIcon /></div>
+										<div>	<div className='whitespace-nowrap'>Weighted</div><PeopleIcon /></div>
 
 								}
 
@@ -172,32 +173,57 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 										</div>
 									</>
 
-							
-								</div>:
-									budget>0 &&<div className="flex flex-row space-x-1 items-center">
-										<div className="pr-2 pt-1">
-											<Image
-												src="/crypto-logos/ETH.svg"
-												alt="avatarUrl"
-												width="12"
-												height="20"
-											/>
-										</div>
-
+								</div> :
+									budget > 0 ?
 										<>
-											<div className="font-semibold ">Budget</div>
-											<div className="">
-												{appState.utils.formatter.format(budget)}
+											<div className="flex flex-row space-x-1 items-center">
+												<div className="pr-2 pt-1">
+													<Image
+														src="/crypto-logos/ETH.svg"
+														alt="avatarUrl"
+														width="12"
+														height="20"
+													/>
+												</div>
+
+												<>
+													<div className="font-semibold ">Budget</div>
+													<div className="">
+														{appState.utils.formatter.format(budget)}
+													</div>
+												</>
 											</div>
 										</>
+										:
+										<div className="flex gap-2">
+											<div className="flex flex-row space-x-1 items-center">
+												<div className="pr-2 pt-1">
+													<Image
+														src="/crypto-logos/ETH.svg"
+														alt="avatarUrl"
+														width="12"
+														height="20"
+													/>
+												</div>
 
-							
-									</div>}
+												<>
+													<div className="font-semibold ">Budget</div>
+												</>
+											</div>
+											<div className="flex flex-row space-x-1 items-center">
+												<ToolTipNew
+													innerStyles={'whitespace-normal w-60'}
+													toolTipText={'No budget has been set for this contract'} >
+													<div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>?</div>
+												</ToolTipNew>
+											</div>
+										</ div>
+								}
 							</div>
 						</div>}
 				</div>
 			</div>
-		</div>
+		</div >
 	);
 };
 

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -68,17 +68,19 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 					</> : <span className='font-semibold text-muted'>No linked pull requests</span>}
 				</div>
 
-				{showTweetLink && <Link
-					href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyId}/${bounty.bountyAddress}`}
-
-				>
-					<a className="hover:scale-105 animate-single-bounce duration-100" target="_blank" rel="noopener noreferrer">
-						<svg viewBox="0 0 128 128" width="24" height="24">
-							<path d="M40.254 127.637c48.305 0 74.719-48.957 74.719-91.403 0-1.39 0-2.777-.075-4.156 5.141-4.547 9.579-10.18 13.102-16.633-4.79 2.602-9.871 4.305-15.078 5.063 5.48-4.02 9.582-10.336 11.539-17.774-5.156 3.743-10.797 6.38-16.68 7.801-8.136-10.586-21.07-13.18-31.547-6.32-10.472 6.86-15.882 21.46-13.199 35.617C41.922 38.539 22.246 26.336 8.915 6.27 1.933 20.94 5.487 39.723 17.022 49.16c-4.148-.172-8.207-1.555-11.832-4.031v.41c0 15.273 8.786 28.438 21.02 31.492a21.596 21.596 0 01-11.863.543c3.437 13.094 13.297 22.07 24.535 22.328-9.305 8.918-20.793 13.75-32.617 13.72-2.094 0-4.188-.15-6.266-.446 12.008 9.433 25.98 14.441 40.254 14.422" fill="#ffffff">
-							</path>
-						</svg>
-					</a>
-				</Link>}
+				{showTweetLink &&
+					<div className='flex items-center border-b border-web-gray py-3 gap-4'>
+						<div className='font-semibold text-muted'>Tweet about it</div>
+						<Link href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyId}/${bounty.bountyAddress}`}>
+							<a className="hover:scale-105 animate-single-bounce duration-100" target="_blank" rel="noopener noreferrer">
+								<svg viewBox="0 0 128 128" width="18" height="18">
+									<path d="M40.254 127.637c48.305 0 74.719-48.957 74.719-91.403 0-1.39 0-2.777-.075-4.156 5.141-4.547 9.579-10.18 13.102-16.633-4.79 2.602-9.871 4.305-15.078 5.063 5.48-4.02 9.582-10.336 11.539-17.774-5.156 3.743-10.797 6.38-16.68 7.801-8.136-10.586-21.07-13.18-31.547-6.32-10.472 6.86-15.882 21.46-13.199 35.617C41.922 38.539 22.246 26.336 8.915 6.27 1.933 20.94 5.487 39.723 17.022 49.16c-4.148-.172-8.207-1.555-11.832-4.031v.41c0 15.273 8.786 28.438 21.02 31.492a21.596 21.596 0 01-11.863.543c3.437 13.094 13.297 22.07 24.535 22.328-9.305 8.918-20.793 13.75-32.617 13.72-2.094 0-4.188-.15-6.266-.446 12.008 9.433 25.98 14.441 40.254 14.422" fill="#ffffff">
+									</path>
+								</svg>
+							</a>
+						</Link>
+					</div>
+				}
 			</div>
 
 		</div>

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -21,8 +21,9 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 		<div className="w-2/3 lg:w-1/2 pb-20">
 		{console.log(bounty)}
 			<div className="flex flex-col space-y-5">
-				<h2 className="flex text-3xl justify-center pt-16">Bounty Closed</h2>
-				<div className="flex justify-center rounded-sm px-6 py-4 pb-4 cursor-pointer" >			
+				<h2 className="flex text-3xl pt-8 border-b border-gray-700 pb-4">This contract is closed.</h2>
+				<h3 className="flex text-2xl pt-2">You cannot initiate actions on a closed contract.</h3>
+				<div className="flex rounded-sm py-4 pb-4 cursor-pointer" >			
 					<div className="my-2">Closing Transaction: <Link href={url}>
 						<a target={'_blank'} rel="noopener norefferer"  className="cursor-pointer break-all">
 							<span className="underline">{url}</span>

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -18,25 +18,24 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 	const claimantPullRequestURL = bounty.closerData;
 	//Render
 	return (
-		<div className="w-2/3 lg:w-1/2 pb-20">
-		{console.log(bounty)}
-			<div className="flex flex-col space-y-5">
-				<h2 className="flex text-3xl pt-8 border-b border-gray-700 pb-4">This contract is closed.</h2>
-				<h3 className="flex text-2xl pt-2">You cannot initiate actions on a closed contract.</h3>
-				<div className="flex rounded-sm py-4 pb-4 cursor-pointer" >			
-					<div className="my-2">Closing Transaction: <Link href={url}>
-						<a target={'_blank'} rel="noopener norefferer"  className="cursor-pointer break-all">
+		<div className='flex w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
+			<div className='flex-1 pr-4 min-w-[260px] space-y-4 pt-2'>
+				<h2 className="flex text-3xl border-b border-gray-700 pb-4">This contract is closed.</h2>
+				<h3 className="flex text-2xl">You cannot initiate actions on a closed contract.</h3>
+				<div className="flex rounded-sm py-2 cursor-pointer" >
+					<div>Closing Transaction: <Link href={url}>
+						<a target={'_blank'} rel="noopener norefferer" className="cursor-pointer break-all">
 							<span className="underline">{url}</span>
 							{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
 							</svg>
 						</a>
 					</Link>
-					{claimantPullRequestURL !== null ?
-						<div className='py-4'>Closing Pull Request: <Link href={claimantPullRequestURL}>
-							<a target="_blank" rel="noopener noreferrer" className='underline'>{claimantPullRequestURL}	
-								{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
-								</svg></a></Link>
-						</div> : null}
+						{claimantPullRequestURL !== null ?
+							<div className='py-4'>Closing Pull Request: <Link href={claimantPullRequestURL}>
+								<a target="_blank" rel="noopener noreferrer" className='underline'>{claimantPullRequestURL}
+									{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
+									</svg></a></Link>
+							</div> : null}
 					</div>
 					{showTweetLink && <Link
 						href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyId}/${bounty.bountyAddress}`}

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -23,19 +23,24 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 				<h2 className="flex text-3xl border-b border-gray-700 pb-4">This contract is closed.</h2>
 				<h3 className="flex text-2xl">You cannot initiate actions on a closed contract.</h3>
 				<div className="flex rounded-sm py-2 cursor-pointer" >
-					<div>Closing Transaction: <Link href={url}>
+					<div>You can see the closing transaction <Link href={url}>
 						<a target={'_blank'} rel="noopener norefferer" className="cursor-pointer break-all">
-							<span className="underline">{url}</span>
+							<span className="underline">here</span>
 							{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
 							</svg>
 						</a>
 					</Link>
+					{console.log(claimantPullRequestURL)}
 						{claimantPullRequestURL !== null ?
-							<div className='py-4'>Closing Pull Request: <Link href={claimantPullRequestURL}>
-								<a target="_blank" rel="noopener noreferrer" className='underline'>{claimantPullRequestURL}
+							<div className='py-4'>You can see the closing pull request <Link href={claimantPullRequestURL}>
+								<a target="_blank" rel="noopener noreferrer" className='cursor-pointer break-all'>
+									<span className="underline">here</span>
 									{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
 									</svg></a></Link>
-							</div> : null}
+							</div>
+							:
+							null
+						}
 					</div>
 					{showTweetLink && <Link
 						href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyId}/${bounty.bountyAddress}`}

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -1,6 +1,7 @@
 // Third party
 import React, { useContext } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 
 import StoreContext from '../../store/Store/StoreContext';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
@@ -23,24 +24,61 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 				<h2 className="flex text-3xl border-b border-gray-700 pb-4">This contract is closed.</h2>
 				<h3 className="flex text-2xl">You cannot initiate actions on a closed contract.</h3>
 				<div className="flex rounded-sm py-2 cursor-pointer" >
-					<div>You can see the closing transaction <Link href={url}>
-						<a target={'_blank'} rel="noopener norefferer" className="cursor-pointer break-all">
-							<span className="underline">here</span>
-							{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
-							</svg>
-						</a>
-					</Link>
-					{console.log(claimantPullRequestURL)}
-						{claimantPullRequestURL !== null ?
-							<div className='py-4'>You can see the closing pull request <Link href={claimantPullRequestURL}>
-								<a target="_blank" rel="noopener noreferrer" className='cursor-pointer break-all'>
+					<div className="flex flex-col items-start">
+						<div className='flex flex-row items-center gap-1'>You can see the closing transaction
+							<Link href={url}>
+								<a target={'_blank'} rel="noopener norefferer" className="flex cursor-pointer break-all">
 									<span className="underline">here</span>
-									{'  '}<svg className="h-3 inline" fill="white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M448 80v352c0 26.51-21.49 48-48 48H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48zm-88 16H248.029c-21.313 0-32.08 25.861-16.971 40.971l31.984 31.987L67.515 364.485c-4.686 4.686-4.686 12.284 0 16.971l31.029 31.029c4.687 4.686 12.285 4.686 16.971 0l195.526-195.526 31.988 31.991C358.058 263.977 384 253.425 384 231.979V120c0-13.255-10.745-24-24-24z" />
-									</svg></a></Link>
+									{'  '}
+									<div id={'bounty-link'} className="flex pl-1 cursor-pointer items-center">
+										<Image src="/BountyMaterial/polyscan-white.png" width={18} height={18} />
+									</div>
+								</a>
+							</Link>
+						</div>
+
+						{console.log(claimantPullRequestURL)}
+						{console.log(bounty.closerData)}
+						{claimantPullRequestURL !== null ?
+							<div className='flex py-4'>You can see the closing pull request <Link href={claimantPullRequestURL}>
+								<a target="_blank" rel="noopener noreferrer" className='flex items-center gap-1 cursor-pointer break-all'>
+									<span className="pl-1 underline">here</span>
+									{'  '}<svg
+										xmlns="http://www.w3.org/2000/svg"
+										width="18"
+										height="18"
+										viewBox="0 0 24 24"
+										fill="white"
+									>
+										<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+									</svg>
+								</a>
+							</Link>
 							</div>
 							:
 							null
 						}
+						<li className='border-b border-web-gray py-3'>
+							{bounty?.prs?.some(pr => pr.source['__typename'] === 'PullRequest' && pr.source.url) > 0 ? <ul>
+
+								<div className='text-xs font-semibold text-muted'>Linked Pull Requests</div>
+								{bounty.prs.filter((pr) => {
+									return pr.source['__typename'] === 'PullRequest' && pr.source.url;
+								}).map((pr, index) => {
+									if (pr.source['__typename'] === 'PullRequest' && pr.source.url) {
+										return <li className='text-sm text-primary' key={index}>
+											<Link href={pr.source.url}>
+												<a target="_blank" className={'underline'}>
+													{pr.source.title}
+												</a>
+											</Link>
+											<span>
+												{pr.source.merged ? ' (merged)' : ' (not merged)'}</span>
+										</li>;
+									}
+								})}
+							</ul> : <span className='text-xs font-semnibold text-muted'>No linked pull requests</span>}
+						</li>
 					</div>
 					{showTweetLink && <Link
 						href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyId}/${bounty.bountyAddress}`}

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -16,83 +16,71 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 	// Hooks
 	const tweetText = `💸 Just claimed a developer bounty from ${bounty.owner} on OpenQ for ${TVL} working on this issue: `;
 	const url = `${process.env.NEXT_PUBLIC_BLOCK_EXPLORER_BASE_URL}/tx/${bounty.claimedTransactionHash}`;
-	const claimantPullRequestURL = bounty.closerData;
+
 	//Render
 	return (
 		<div className='flex w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
 			<div className='flex-1 pr-4 min-w-[260px] space-y-4 pt-2'>
-				<h2 className="flex text-3xl border-b border-gray-700 pb-4">This contract is closed.</h2>
-				<h3 className="flex text-2xl">You cannot initiate actions on a closed contract.</h3>
-				<div className="flex rounded-sm py-2 cursor-pointer" >
-					<div className="flex flex-col items-start">
-						<div className='flex flex-row items-center gap-1'>You can see the closing transaction
-							<Link href={url}>
-								<a target={'_blank'} rel="noopener norefferer" className="flex cursor-pointer break-all">
-									<span className="underline">here</span>
-									{'  '}
-									<div id={'bounty-link'} className="flex pl-1 cursor-pointer items-center">
-										<Image src="/BountyMaterial/polyscan-white.png" width={18} height={18} />
-									</div>
-								</a>
-							</Link>
-						</div>
-
-						{console.log(claimantPullRequestURL)}
-						{console.log(bounty.closerData)}
-						{claimantPullRequestURL !== null ?
-							<div className='flex py-4'>You can see the closing pull request <Link href={claimantPullRequestURL}>
-								<a target="_blank" rel="noopener noreferrer" className='flex items-center gap-1 cursor-pointer break-all'>
-									<span className="pl-1 underline">here</span>
-									{'  '}<svg
-										xmlns="http://www.w3.org/2000/svg"
-										width="18"
-										height="18"
-										viewBox="0 0 24 24"
-										fill="white"
-									>
-										<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-									</svg>
-								</a>
-							</Link>
-							</div>
-							:
-							null
-						}
-						<li className='border-b border-web-gray py-3'>
-							{bounty?.prs?.some(pr => pr.source['__typename'] === 'PullRequest' && pr.source.url) > 0 ? <ul>
-
-								<div className='text-xs font-semibold text-muted'>Linked Pull Requests</div>
-								{bounty.prs.filter((pr) => {
-									return pr.source['__typename'] === 'PullRequest' && pr.source.url;
-								}).map((pr, index) => {
-									if (pr.source['__typename'] === 'PullRequest' && pr.source.url) {
-										return <li className='text-sm text-primary' key={index}>
-											<Link href={pr.source.url}>
-												<a target="_blank" className={'underline'}>
-													{pr.source.title}
-												</a>
-											</Link>
-											<span>
-												{pr.source.merged ? ' (merged)' : ' (not merged)'}</span>
-										</li>;
-									}
-								})}
-							</ul> : <span className='text-xs font-semnibold text-muted'>No linked pull requests</span>}
-						</li>
+				<h2 className="flex text-3xl">This contract is closed.</h2>
+				<h3 className="flex text-2xl border-b border-gray-700 pb-4">You cannot initiate actions on a closed contract.</h3>
+				<div className="flex border-b border-web-gray py-3 gap-2">
+					<div className='font-semibold text-muted'>Linked Closing Transaction</div>
+					<div className='flex gap-1 text-primary'>
+						<Link href={url}>
+							<a target={'_blank'} rel="noopener norefferer" className="flex items-center gap-1 underline">
+								<div id={'bounty-link'} className="flex cursor-pointer items-center">
+									<Image src="/BountyMaterial/polyscan-white.png" width={18} height={18} />
+								</div>
+								<span className="underline pl-1">view here</span>
+							</a>
+						</Link>
 					</div>
-					{showTweetLink && <Link
-						href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyId}/${bounty.bountyAddress}`}
-
-					>
-						<a className="hover:scale-105 animate-single-bounce duration-100" target="_blank" rel="noopener noreferrer">
-							<svg viewBox="0 0 128 128" width="24" height="24">
-								<path d="M40.254 127.637c48.305 0 74.719-48.957 74.719-91.403 0-1.39 0-2.777-.075-4.156 5.141-4.547 9.579-10.18 13.102-16.633-4.79 2.602-9.871 4.305-15.078 5.063 5.48-4.02 9.582-10.336 11.539-17.774-5.156 3.743-10.797 6.38-16.68 7.801-8.136-10.586-21.07-13.18-31.547-6.32-10.472 6.86-15.882 21.46-13.199 35.617C41.922 38.539 22.246 26.336 8.915 6.27 1.933 20.94 5.487 39.723 17.022 49.16c-4.148-.172-8.207-1.555-11.832-4.031v.41c0 15.273 8.786 28.438 21.02 31.492a21.596 21.596 0 01-11.863.543c3.437 13.094 13.297 22.07 24.535 22.328-9.305 8.918-20.793 13.75-32.617 13.72-2.094 0-4.188-.15-6.266-.446 12.008 9.433 25.98 14.441 40.254 14.422" fill="#ffffff">
-								</path>
-							</svg>
-						</a>
-					</Link>}
 				</div>
+
+				<div className='flex flex-col border-b border-web-gray py-3 gap-2'>
+					{bounty?.prs?.some(pr => pr.source['__typename'] === 'PullRequest' && pr.source.url) > 0 ? <>
+
+						<div className='font-semibold text-muted'>Linked Pull Requests</div>
+						{bounty.prs.filter((pr) => {
+							return pr.source['__typename'] === 'PullRequest' && pr.source.url;
+						}).map((pr, index) => {
+							if (pr.source['__typename'] === 'PullRequest' && pr.source.url) {
+								return <div className='flex gap-1 text-primary' key={index}>
+									<Link href={pr.source.url}>
+										<a target="_blank" className={'flex items-center gap-1 underline'}>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												width="18"
+												height="18"
+												viewBox="0 0 24 24"
+												fill="white"
+											>
+												<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+											</svg>
+											{pr.source.title}
+										</a>
+									</Link>
+									<span>
+										{pr.source.merged ? ' (merged)' : ' (not merged)'}</span>
+								</div>;
+							}
+						})}
+					</> : <span className='font-semibold text-muted'>No linked pull requests</span>}
+				</div>
+
+				{showTweetLink && <Link
+					href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/bounty/${bounty.bountyId}/${bounty.bountyAddress}`}
+
+				>
+					<a className="hover:scale-105 animate-single-bounce duration-100" target="_blank" rel="noopener noreferrer">
+						<svg viewBox="0 0 128 128" width="24" height="24">
+							<path d="M40.254 127.637c48.305 0 74.719-48.957 74.719-91.403 0-1.39 0-2.777-.075-4.156 5.141-4.547 9.579-10.18 13.102-16.633-4.79 2.602-9.871 4.305-15.078 5.063 5.48-4.02 9.582-10.336 11.539-17.774-5.156 3.743-10.797 6.38-16.68 7.801-8.136-10.586-21.07-13.18-31.547-6.32-10.472 6.86-15.882 21.46-13.199 35.617C41.922 38.539 22.246 26.336 8.915 6.27 1.933 20.94 5.487 39.723 17.022 49.16c-4.148-.172-8.207-1.555-11.832-4.031v.41c0 15.273 8.786 28.438 21.02 31.492a21.596 21.596 0 01-11.863.543c3.437 13.094 13.297 22.07 24.535 22.328-9.305 8.918-20.793 13.75-32.617 13.72-2.094 0-4.188-.15-6.266-.446 12.008 9.433 25.98 14.441 40.254 14.422" fill="#ffffff">
+							</path>
+						</svg>
+					</a>
+				</Link>}
 			</div>
+
 		</div>
 	);
 };

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -119,7 +119,6 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 		return (
 			bounty.bountyType ?
 				bounty.bountyClosedTime ? <>
-					{console.log(justClaimed)}
 					<BountyClosed bounty={bounty} showTweetLink={justClaimed} />
 					</>
 					:

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -118,9 +118,10 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
 	if (claimable) {
 		return (
 			bounty.bountyType ?
-				bounty.bountyClosedTime ?
-					// case where bounty is not claimable anymore (Atomic Contract and Repeatable Contract closed)
+				bounty.bountyClosedTime ? <>
+					{console.log(justClaimed)}
 					<BountyClosed bounty={bounty} showTweetLink={justClaimed} />
+					</>
 					:
 					// case where bounty not claimable yet (contest not closed yet) 
 					<div className='text-lg'>Contest must be closed in order to be able to claim your rewards.</div>

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -197,7 +197,6 @@ const FundPage = ({ bounty, refreshBounty }) => {
 	return (<>
 		{closed ?
 			<>
-				<h1 className='text-3xl'>Cannot Fund a Closed {bountyName}!</h1>
 				<BountyClosed bounty={bounty} />
 			</>
 			:

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -277,18 +277,19 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
 													</ToolTipNew>
 												</div>
 												<div className='flex-1 w-full mt-2 ml-4'>
-													<div className="flex text-sm rounded-sm overflow-hidden w-fit text-primary ">
-														<ToolTipNew toolTipText={'Invoicing feature coming soon'}>
+													<div className="flex text-sm rounded-sm text-primary ">
+														<ToolTipNew innerStyles={'flex'} toolTipText={'Invoicing feature coming soon'}>
 															<button
+																disabled={true}
 																onClick={() => setInvoice(true)}
-																className="w-fit min-w-[80px] py-[5px] px-4 rounded-l-sm border whitespace-nowrap ${invoice? 'bg-secondary-button border-secondary-button' : null} hover:bg-secondary-button hover:border-secondary-button border-web-gray"
+																className={`cursor-not-allowed w-fit min-w-[80px] py-[5px] px-4 rounded-l-sm border whitespace-nowrap ${invoice? 'bg-secondary-button border-secondary-button' : ''}  border-web-gray`}
 															>
 																Yes
 															</button>
 														</ToolTipNew>
 														<button
 															onClick={() => setInvoice(false)}
-															className={`w-fit min-w-[80px] py-[5px] px-4 border-l-0 rounded-r-sm border whitespace-nowrap ${!invoice? 'bg-secondary-button border-secondary-button' : null} hover:bg-secondary-button hover:border-secondary-button border-web-gray`}
+															className={`w-fit min-w-[80px] py-[5px] px-4 border-l-0 rounded-r-sm border whitespace-nowrap ${!invoice? 'bg-secondary-button border-secondary-button' : 'hover:bg-secondary-button hover:border-secondary-button border-web-gray'} `}
 														>
 															No
 														</button>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -49,7 +49,7 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
 	const [finalTierVolume, setFinalTierVolume] = useState([]);
 	const [payoutVolume, setPayoutVolume] = useState('');
 	const [payoutToken, setPayoutToken] = useState(zeroAddressMetadata);
-	const initialType =  types[0]==='1' ? 'Repeating' : types[0] ==='2'? 'Contest': 'Atomic';
+	const initialType = types[0] === '1' ? 'Repeating' : types[0] === '2' ? 'Contest' : 'Atomic';
 	const [toggleType, setToggleType] = useState(initialType);
 	const [goalVolume, setGoalVolume] = useState('');
 	const [goalToken, setGoalToken] = useState(zeroAddressMetadata);
@@ -115,17 +115,17 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
 			setIsLoading(true);
 			let data;
 			switch (toggleType) {
-			case 'Atomic':
-				data = { fundingTokenVolume: goalVolume, fundingTokenAddress: goalToken };
-				break;
-			case 'Repeating':
-				data = { payoutVolume: payoutVolume, payoutToken: payoutToken, fundingTokenVolume: goalVolume, fundingTokenAddress: goalToken };
-				break;
-			case 'Contest':
-				data = { fundingTokenVolume: goalVolume, fundingTokenAddress: goalToken, tiers: finalTierVolume };
-				break;
-			default:
-				throw new Error(`No type: ${toggleType}`);
+				case 'Atomic':
+					data = { fundingTokenVolume: goalVolume, fundingTokenAddress: goalToken };
+					break;
+				case 'Repeating':
+					data = { payoutVolume: payoutVolume, payoutToken: payoutToken, fundingTokenVolume: goalVolume, fundingTokenAddress: goalToken };
+					break;
+				case 'Contest':
+					data = { fundingTokenVolume: goalVolume, fundingTokenAddress: goalToken, tiers: finalTierVolume };
+					break;
+				default:
+					throw new Error(`No type: ${toggleType}`);
 			}
 
 			const { bountyAddress } = await appState.openQClient.mintBounty(
@@ -266,26 +266,40 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
 										<BountyAlreadyMintedMessage claimed={claimed} id={issue.id} bountyAddress={bountyAddress} />}
 								</div>
 
-								{toggleType ?
-									<>
-										<div className="flex flex-col items-center pl-6 pr-6 pb-2">
-											<div className="flex flex-col w-4/5 md:w-2/3">
-												<div className='flex flex-col w-full items-start p-2 py-1 text-base bg-[#161B22]'>
-													<div className='flex items-center gap-2'>Is this Contract invoiceable?
-														<ToolTipNew mobileX={10} toolTipText={'Do you want an invoice for this contract?'} >
-															<div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>?</div>
+
+								<>
+									<div className="flex flex-col items-center pl-6 pr-6 pb-2">
+										<div className="flex flex-col w-4/5 md:w-2/3">
+											<div className='flex flex-col w-full items-start p-2 py-1 text-base bg-[#161B22]'>
+												<div className='flex items-center gap-2'>Is this Contract invoiceable?
+													<ToolTipNew mobileX={10} toolTipText={'Do you want an invoice for this contract?'} >
+														<div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>?</div>
+													</ToolTipNew>
+												</div>
+												<div className='flex-1 w-full mt-2 ml-4'>
+													<div className="flex text-sm rounded-sm overflow-hidden w-fit text-primary ">
+														<ToolTipNew toolTipText={'Invoicing feature coming soon'}>
+															<button
+																onClick={() => setInvoice(true)}
+																className="w-fit min-w-[80px] py-[5px] px-4 rounded-l-sm border whitespace-nowrap ${invoice? 'bg-secondary-button border-secondary-button' : null} hover:bg-secondary-button hover:border-secondary-button border-web-gray"
+															>
+																Yes
+															</button>
 														</ToolTipNew>
-													</div>
-													<div className='flex-1 w-full mt-2 ml-4'>
-														<SmallToggle names={['Yes', 'No']} toggleVal={invoice ? 'Yes' : 'No'} toggleFunc={() => setInvoice(!invoice)} />
+														<button
+															onClick={() => setInvoice(false)}
+															className={`w-fit min-w-[80px] py-[5px] px-4 border-l-0 rounded-r-sm border whitespace-nowrap ${!invoice? 'bg-secondary-button border-secondary-button' : null} hover:bg-secondary-button hover:border-secondary-button border-web-gray`}
+														>
+															No
+														</button>
+
 													</div>
 												</div>
 											</div>
 										</div>
-									</>
-									:
-									null
-								}
+									</div>
+								</>
+
 								<div className="flex flex-col items-center pl-6 pr-6 pb-2">
 									<div className="flex flex-col w-4/5 md:w-2/3">
 										<div className='flex flex-col w-full items-start p-2 py-1 text-base bg-[#161B22]'>
@@ -297,7 +311,7 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
 												</ToolTipNew>
 											</div>
 											<span className='text-sm my-2'>You don{'\''}t have to deposit now! The budget is just what you intend to pay.</span>
-											{ budgetInput?
+											{budgetInput ?
 												<div className='flex-1 w-full mt-2 ml-4'>
 													<TokenFundBox
 														onCurrencySelect={onGoalCurrencySelect}
@@ -396,7 +410,7 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
 										outerStyles={''}
 										hideToolTip={(enableContest && enableMint && isOnCorrectNetwork && !issue?.closed && account) || isLoading}
 										toolTipText={
-											account && isOnCorrectNetwork && !enableMint?
+											account && isOnCorrectNetwork && !enableMint ?
 												'Please choose an elgible issue.' :
 												!enableContest ?
 													'Please make sure the sum of tier percentages adds up to 100.' :

--- a/components/RefundBounty/RefundPage.js
+++ b/components/RefundBounty/RefundPage.js
@@ -38,7 +38,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
 	const { library, account, } = useWeb3();
 	const [ensName] = useEns(account);
 
-	const claimed = bounty.status == 'CLOSED';
+	const closed = bounty.bountyClosedTime;
 
 	// Side Effects
 	useEffect(() => {
@@ -108,7 +108,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
 	// Render
 
 	return (
-		<>{claimed ?
+		<>{closed ?
 			<>{internalMenu === 'Refund' && <BountyClosed bounty={bounty} />}</> :
 
 

--- a/components/Utils/Dropdown.js
+++ b/components/Utils/Dropdown.js
@@ -30,7 +30,7 @@ const Dropdown = ({ toggleFunc, toggleVal, names, title, styles, width }) => {
 	};
 
 
-	const handleToggle = (e)=>{
+	const handleToggle = (e) => {
 		e.preventDefault();
 		updateOpen(!open);
 	};
@@ -38,21 +38,26 @@ const Dropdown = ({ toggleFunc, toggleVal, names, title, styles, width }) => {
 	// Render
 	return (
 		<details ref={ref} open={open} onClick={handleToggle} className={`max-h-8 ${styles} text-sm text-muted cursor-pointer`}>
-			<summary  className={`inline-flex justify-between w-${width} rounded-l-sm border-border-default text-primary rounded-l-smleading-2 py-[5px] px-4`}>{title||toggleVal}
-			
+			<summary className={`inline-flex justify-between w-${width} rounded-l-sm border-border-default text-primary rounded-l-smleading-2 py-[5px] px-4`}>{title || toggleVal}
+
 				<svg xmlns="http://www.w3.org/2000/svg" className='fill-muted relative top-1' viewBox="0 0 16 16" width="16" height="16"><path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z"></path></svg>
 			</summary>
 			<div className='w-0'>
 				<ul className='z-20 relative bg-subtle w-60 mt-2 mb-4 shadow-[rgb(1,_4,_9)_0px_8px_24px_0px] border-web-gray border rounded-sm'>
-					{names.map(name=>
-				
-						<li key = {name}>
-							<button className="w-full text-left p-2 px-4 hover:bg-dropdown-hover" onClick={handleSelection} value={name}>
-								{name}
-							</button>
-						</li>
-					)}
-				</ul></div>
+					{names.length > 0 ?
+						<>
+							{names.map(name =>
+								<li key={name}>
+									<button className="w-full text-left p-2 px-4 hover:bg-dropdown-hover" onClick={handleSelection} value={name}>
+										{name}
+									</button>
+								</li>
+							)} </>
+						:
+						<div className="w-full text-left p-2 px-4">no label available</div>
+					}
+				</ul>
+			</div>
 		</details>);
 };
 export default Dropdown;

--- a/pages/bounty/[id]/[address].js
+++ b/pages/bounty/[id]/[address].js
@@ -87,7 +87,8 @@ const address = ({ address, mergedBounty, renderError }) => {
       && JSON.stringify(newBounty.deposits) === JSON.stringify(bounty.deposits)
       && newBounty.bountyClosedTime === bounty.bountyClosedTime
 			&& newBounty.fundingGoalVolume === bounty.fundingGoalVolume
-			&& newBounty.payoutTokenVolume === bounty.payoutTokenVolume) {
+			&& newBounty.payoutTokenVolume === bounty.payoutTokenVolume
+			&& newBounty.payoutSchedule === bounty.payoutSchedule) {
 				newBounty = await appState.openQSubgraphClient.getBounty(address, 'no-cache');
 				await sleep(500);
 			}

--- a/services/ethers/OpenQClient.js
+++ b/services/ethers/OpenQClient.js
@@ -132,6 +132,25 @@ class OpenQClient {
 		return promise;
 	}
 
+	async setPayoutSchedule(library, _bountyId, _payoutSchedule) {
+		const promise = new Promise(async (resolve, reject) => {
+			const signer = library.getSigner();
+			const contract = this.OpenQ(signer);
+			try {
+				let txnResponse;
+				let txnReceipt;
+				txnResponse = await contract.setPayoutSchedule(_bountyId, _payoutSchedule);
+				txnReceipt = await txnResponse.wait();
+				console.log(txnReceipt);
+				resolve(txnReceipt);
+			} catch (error) {
+				console.log(error);
+				reject(error);
+			}
+		});
+		return promise;
+	}
+
 	async approve(library, _bountyAddress, _tokenAddress, _value) {
 		const promise = new Promise(async (resolve, reject) => {
 			const signer = library.getSigner();

--- a/services/ethers/OpenQClient.js
+++ b/services/ethers/OpenQClient.js
@@ -44,7 +44,7 @@ class OpenQClient {
 			let bountyInitOperation;
 			let abiCoder = new ethers.utils.AbiCoder;
 			const fundVolumeInWei = data.fundingTokenVolume * 10 ** data.fundingTokenAddress.decimals;
-			const fundBigNumberVolumeInWei = ethers.BigNumber.from(fundVolumeInWei.toString());
+			const fundBigNumberVolumeInWei = ethers.BigNumber.from(fundVolumeInWei.toLocaleString('fullwide', {useGrouping:false}));
 			const hasFundingGoal = fundVolumeInWei > 0;
 			switch (type) {
 
@@ -57,7 +57,7 @@ class OpenQClient {
 			case 'Repeating':
 				{
 					const payoutVolumeInWei = data.payoutVolume * 10 ** data.payoutToken.decimals;
-					const payoutBigNumberVolumeInWei = ethers.BigNumber.from(payoutVolumeInWei.toString());
+					const payoutBigNumberVolumeInWei = ethers.BigNumber.from(payoutVolumeInWei.toLocaleString('fullwide', {useGrouping:false}));
 					const ongoingAbiEncodedParams = abiCoder.encode(['address', 'uint256', 'bool', 'address', 'uint256'], [data.payoutToken.address, payoutBigNumberVolumeInWei, hasFundingGoal, data.fundingTokenAddress.address, fundBigNumberVolumeInWei]);
 					bountyInitOperation = [1, ongoingAbiEncodedParams];
 				}
@@ -93,7 +93,7 @@ class OpenQClient {
 	async setFundingGoal(library, _bountyId, _fundingGoalToken, _fundingGoalVolume) {
 		const promise = new Promise(async (resolve, reject) => {
 			const volumeInWei = _fundingGoalVolume * 10 ** _fundingGoalToken.decimals;
-			const bigNumberVolumeInWei = ethers.BigNumber.from(volumeInWei.toString());
+			const bigNumberVolumeInWei = ethers.BigNumber.from(volumeInWei.toLocaleString('fullwide', {useGrouping:false}));
 			const signer = library.getSigner();
 			const contract = this.OpenQ(signer);
 			try {

--- a/services/utils/Utils.js
+++ b/services/utils/Utils.js
@@ -140,7 +140,7 @@ class Utils {
 				return {status: 'Ready for Work', colour: 'bg-green', fill: 'fill-green'};
 			}
 		}
-		else if (bounty.closed){
+		else if (bounty.bountyClosedTime){
 			return{status: 'Closed', colour: 'bg-closed', fill: 'fill-closed'};
 		}
 		else{return {status: 'Open', colour: 'bg-green', fill: 'fill-green'}; }


### PR DESCRIPTION
closes #603 
In AdminPage, setPayoutSchedule now updates the data (linked smart contract). 
The AdminModal was also modified accordingly.
Correcting error when going on AdminPage and not type 1.

closes #595 
BountyClosed: removed double header, changed title and description, corrected conditions to show BountyClosed, changed info (PR and right links), and modified BountyMarker so that it reacts on close (closed remains false atm for type 1 and 2 so we need bountyClosedTime as a condition to check whether they are closed or not)

closes #613 
Invoiceable button Yet disabled with tooltip.

closes #614 
No more error for Budget > 1000 => Replaced .toString() with .toLocaleString('fullwide', {useGrouping:false}) in relevant budget code in OpenQClient.js

closes #621 
Shows "no label available" when no labels in filter dropdown

closes #620 
on the BountyCardLean overview, added Budget and the tooltip indicating that no budget was set yet. Also right aligned all budget/TVL info, and made sure the bounty type and corresponding symbol are on the same line.

![image](https://user-images.githubusercontent.com/75732239/185433153-d10e4748-866a-4362-9b1c-2c050a2f0b57.png)

![image](https://user-images.githubusercontent.com/75732239/185594001-1ca717ac-730f-422b-a633-49f38f53860c.png)

![image](https://user-images.githubusercontent.com/75732239/185594067-a50d2ea2-359c-44b8-a9e4-ec440d685f9e.png)

![image](https://user-images.githubusercontent.com/75732239/185611737-f79a659e-0772-4948-b0e7-5f0e5f7b2f41.png)

![image](https://user-images.githubusercontent.com/75732239/185624206-b4c10a06-13c7-4b7d-9759-d2e9d222374e.png)

![image](https://user-images.githubusercontent.com/75732239/185645890-89195c56-dbed-41ae-b69f-3fa2417c62ee.png)

