### PR TITLE
Extend deposit button FE logic

### DIFF
--- a/__tests__/MintBounty/IssueDetailsBubble.test.js
+++ b/__tests__/MintBounty/IssueDetailsBubble.test.js
@@ -116,7 +116,7 @@ describe('IssueDetailsBubble', () => {
     // ARRANGE
     render(<IssueDetailsBubble issueData={mintableIssue} />);
 
-    expect(screen.getByText('Created on May 3, 2022 at 7:05')).toBeInTheDocument();
+    expect(screen.getByText('Created on May 3, 2022 at 11:05')).toBeInTheDocument();
     expect(screen.getByText(/Mintable Issue/i)).toBeInTheDocument();
     // should not have null or undefined values
     const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
@@ -127,7 +127,7 @@ describe('IssueDetailsBubble', () => {
     // ARRANGE
     render(<IssueDetailsBubble issueData={unmintableIssue} />);
 
-    expect(screen.getByText('Created on May 3, 2022 at 7:05')).toBeInTheDocument();
+    expect(screen.getByText('Created on May 3, 2022 at 11:05')).toBeInTheDocument();
     expect(screen.getByText(/Mintable Issue/i)).toBeInTheDocument();
     // should not have null or undefined values
     const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];

--- a/__tests__/RefundBounty/DepositCard.test.js
+++ b/__tests__/RefundBounty/DepositCard.test.js
@@ -48,29 +48,7 @@
         refundTime: '1662407371',
         sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
         __typename: 'Deposit',
-      },
-      {
-        id: '0x8f5c1c912b8ffca325a22eadb33d6d54fa8e85b3752f2392eb54ecc6dd24b1e1',
-        refunded: false,
-        receiveTime: '1662395948',
-        tokenAddress: '0x0000000000000000000000000000000000000000',
-        expiration: '2592000',
-        volume: '23000000000000000000',
-        refundTime: null,
-        sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
-        __typename: 'Deposit',
-      },
-      {
-        id: '0x9c5e530511dff239da2c1c1205649aaa24fe2cc797d583a162744f26d623726a',
-        refunded: false,
-        receiveTime: '1662395897',
-        tokenAddress: '0x0000000000000000000000000000000000000000',
-        expiration: '2592000',
-        volume: '23000000000000000000',
-        refundTime: null,
-        sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
-        __typename: 'Deposit',
-      },
+      }
      ];
    const isoDate = 1662396272728;
    const RealDate = Date;
@@ -86,7 +64,7 @@
    });
  
    const test = (deposit) => {
-     it('should render the heading', async () => {
+     it('should render the volume and name of token', async () => {
        // ARRANGE
        render(<DepositCard deposit={deposit} />);
        let heading = await screen.findByText(/23.00 MATIC/i);
@@ -95,7 +73,7 @@
        expect(heading).toBeInTheDocument();
      });
  
-     it('should render refundable', async () => {
+     it('should render refund and extend button when refundable', async () => {
        // ARRANGE
        render(<DepositCard deposit={deposit} status={'refundable'} />);
        const refundBtn = await screen.findByRole('button', { name: /Refund/i });
@@ -109,22 +87,32 @@
        const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
        expect(nullish).toHaveLength(0);
      });
-     it('should render times, including not yet refundable times', async () => {
+     it('should render times whether refundable or not', async () => {
        // ARRANGE
        render(<DepositCard deposit={deposit} />);
  
        const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
        // ASSERT
        expect(nullish).toHaveLength(0);
-       expect(screen.getByText(/Refundable on: September 5, 2022 at 16:44/)).toBeInTheDocument();
+       if(deposit.refunded) {
+        expect(screen.getByText(/Refunded on: September 5, 2022 at 16:44/)).toBeInTheDocument();
+       } else {
+        expect(screen.getByText(/Refundable on: September 5, 2022 at 16:44/)).toBeInTheDocument();
+       }
      });
  
-     it('should render refunded', async () => {
+     it('should render extend button when not refunded yet', async () => {
        // ARRANGE
-       render(<DepositCard deposit={deposits[3]} />);
+       render(<DepositCard deposit={deposit} />);
+       const extendBtn = await screen.findByRole('button', { name: /Extend/i });
  
        // ASSERT
-       expect(screen.getAllByText(/Refunded on: September 5, 2022 at 16:44/)).toHaveLength(1);
+       if(deposit.status !== 'refunded') {
+        expect(extendBtn).toBeInTheDocument();
+       } else {
+        expect(extendBtn).toHaveLength(0);
+       }
+       
        const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
        expect(nullish).toHaveLength(0);
      });

--- a/__tests__/RefundBounty/DepositCard.test.js
+++ b/__tests__/RefundBounty/DepositCard.test.js
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+ import React from 'react';
+ import { render, screen } from '../../test-utils';
+ import DepositCard from '../../components/RefundBounty/DepositCard';
+ import InitialState from '../../store/Store/InitialState';
+ 
+ describe('DepositCard', () => {
+   const deposits = [
+       {
+         id: '0xbf3f0b23ed5abb06f6ea2bdc516729d30cd5e9731a7a31ef77ef5382488455b2',
+         refunded: false,
+         receiveTime: '1662395968',
+         tokenAddress: '0x0000000000000000000000000000000000000000',
+         expiration: '1',
+         volume: '23000000000000000000',
+         sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+         __typename: 'Deposit',
+       },
+       {
+         id: '0x8f5c1c912b8ffca325a22eadb33d6d54fa8e85b3752f2392eb54ecc6dd24b1e1',
+         refunded: false,
+         receiveTime: '1662395948',
+         tokenAddress: '0x0000000000000000000000000000000000000000',
+         expiration: '2592000',
+         volume: '23000000000000000000',
+         sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+         __typename: 'Deposit',
+       },
+       {
+         id: '0x9c5e530511dff239da2c1c1205649aaa24fe2cc797d583a162744f26d623726a',
+         refunded: false,
+         receiveTime: '1662395897',
+         tokenAddress: '0x0000000000000000000000000000000000000000',
+         expiration: '2592000',
+         volume: '23000000000000000000',
+         sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+         __typename: 'Deposit',
+       },
+       {
+        id: '0xbf3f0b23ed5abb06f6ea2bdc516729d30cd5e9731a7a31ef77ef5382488455b2',
+        refunded: true,
+        receiveTime: '1662395968',
+        tokenAddress: '0x0000000000000000000000000000000000000000',
+        expiration: '1',
+        volume: '23000000000000000000',
+        refundTime: '1662407371',
+        sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+        __typename: 'Deposit',
+      },
+      {
+        id: '0x8f5c1c912b8ffca325a22eadb33d6d54fa8e85b3752f2392eb54ecc6dd24b1e1',
+        refunded: false,
+        receiveTime: '1662395948',
+        tokenAddress: '0x0000000000000000000000000000000000000000',
+        expiration: '2592000',
+        volume: '23000000000000000000',
+        refundTime: null,
+        sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+        __typename: 'Deposit',
+      },
+      {
+        id: '0x9c5e530511dff239da2c1c1205649aaa24fe2cc797d583a162744f26d623726a',
+        refunded: false,
+        receiveTime: '1662395897',
+        tokenAddress: '0x0000000000000000000000000000000000000000',
+        expiration: '2592000',
+        volume: '23000000000000000000',
+        refundTime: null,
+        sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+        __typename: 'Deposit',
+      },
+     ];
+   const isoDate = 1662396272728;
+   const RealDate = Date;
+   global.Date = class extends RealDate {
+     constructor() {
+       super();
+       return new RealDate(isoDate);
+     }
+   };
+ 
+   beforeEach(() => {
+     InitialState.openQClient.reset();
+   });
+ 
+   const test = (deposit) => {
+     it('should render the heading', async () => {
+       // ARRANGE
+       render(<DepositCard deposit={deposit} />);
+       let heading = await screen.findByText(/23.00 MATIC/i);
+ 
+       // ASSERT
+       expect(heading).toBeInTheDocument();
+     });
+ 
+     it('should render refundable', async () => {
+       // ARRANGE
+       render(<DepositCard deposit={deposit} status={'refundable'} />);
+       const refundBtn = await screen.findByRole('button', { name: /Refund/i });
+       const extendBtn = await screen.findByRole('button', { name: /Extend/i });
+ 
+       // ASSERT
+       expect(refundBtn).toBeInTheDocument();
+       expect(extendBtn).toBeInTheDocument();
+ 
+       // ASSERT
+       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+       expect(nullish).toHaveLength(0);
+     });
+     it('should render times, including not yet refundable times', async () => {
+       // ARRANGE
+       render(<DepositCard deposit={deposit} />);
+ 
+       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+       // ASSERT
+       expect(nullish).toHaveLength(0);
+       expect(screen.getByText(/Refundable on: September 5, 2022 at 16:44/)).toBeInTheDocument();
+     });
+ 
+     it('should render refunded', async () => {
+       // ARRANGE
+       render(<DepositCard deposit={deposits[3]} />);
+ 
+       // ASSERT
+       expect(screen.getAllByText(/Refunded on: September 5, 2022 at 16:44/)).toHaveLength(1);
+       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+       expect(nullish).toHaveLength(0);
+     });
+   };
+ 
+   deposits.forEach((deposit) => test(deposit));
+ });
+ 

--- a/__tests__/RefundBounty/RefundPage.test.js
+++ b/__tests__/RefundBounty/RefundPage.test.js
@@ -203,12 +203,12 @@ describe('RefundPage', () => {
       render(<RefundPage bounty={bounty} />);
       let heading = await screen.findByText('Your Deposits');
       const refundBtn = await screen.findByRole('button', { name: /Refund/i });
-      const extendBtn = await screen.findByRole('button', { name: /Extend/i });
+      const extendBtn = await screen.findAllByRole('button', { name: /Extend/i });
 
       // ASSERT
       expect(heading).toBeInTheDocument();
       expect(refundBtn).toBeInTheDocument();
-      expect(extendBtn).toBeInTheDocument();
+      expect(extendBtn).toHaveLength(3);
 
       // ASSERT
       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
@@ -221,7 +221,7 @@ describe('RefundPage', () => {
       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
       // ASSERT
       expect(nullish).toHaveLength(0);
-      expect(screen.getAllByText(/Refundable on: September 5, 2022 at 12:44/)).toHaveLength(3);
+      expect(screen.getAllByText(/Refundable on: September 5, 2022 at 16:44/)).toHaveLength(3);
     });
 
     it('should render refunded', async () => {
@@ -232,7 +232,7 @@ describe('RefundPage', () => {
       // ASSERT
       expect(heading).toBeInTheDocument();
       // ASSERT
-      expect(screen.getAllByText(/Refunded on: September 5, 2022 at 12:44/)).toHaveLength(1);
+      expect(screen.getAllByText(/Refunded on: September 5, 2022 at 16:44/)).toHaveLength(1);
       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
       expect(nullish).toHaveLength(0);
     });

--- a/__tests__/User/AboutModules/DepositList.test.js
+++ b/__tests__/User/AboutModules/DepositList.test.js
@@ -53,13 +53,13 @@ describe('DepositList', () => {
     render(<DepositList deposits={deposits} />);
 
     // ASSERT
-    expect(screen.getByText(/Deposited on: June 3, 2022 at 8:54/)).toBeInTheDocument();
+    expect(screen.getByText(/Deposited on: June 3, 2022 at 12:54/)).toBeInTheDocument();
   });
   it('should render Bounty heading', async () => {
     // ARRANGE
     render(<DepositList deposits={deposits} />);
 
     // ASSERT
-    expect(screen.getByText(/Refundable on: July 3, 2022 at 8:55/)).toBeInTheDocument();
+    expect(screen.getByText(/Refundable on: July 3, 2022 at 12:55/)).toBeInTheDocument();
   });
 });

--- a/__tests__/User/AboutModules/MiniDepositList.test.js
+++ b/__tests__/User/AboutModules/MiniDepositList.test.js
@@ -53,13 +53,13 @@ describe('MiniDepositList', () => {
     render(<MiniDepositList deposits={deposits} />);
 
     // ASSERT
-    expect(screen.getByText(/Deposited on: June 3, 2022 at 8:54/)).toBeInTheDocument();
+    expect(screen.getByText(/Deposited on: June 3, 2022 at 12:54/)).toBeInTheDocument();
   });
   it('should render Bounty heading', async () => {
     // ARRANGE
     render(<MiniDepositList deposits={deposits} />);
 
     // ASSERT
-    expect(screen.getByText(/Refundable on: July 3, 2022 at 8:55/)).toBeInTheDocument();
+    expect(screen.getByText(/Refundable on: July 3, 2022 at 12:55/)).toBeInTheDocument();
   });
 });

--- a/__tests__/Utils/ActionBubble.test.js
+++ b/__tests__/Utils/ActionBubble.test.js
@@ -180,7 +180,7 @@ describe('ActionBubble', () => {
 
     render(<ActionBubble bounty={bounty} addresses={addresses} />);
     // ASSERT
-    expect(await screen.findByText('sample.eth minted this contract on August 29, 2022 at 6:12.'));
+    expect(await screen.findByText('sample.eth minted this contract on August 29, 2022 at 10:12.'));
     expect(screen.getByText(/body of test2/i)).toBeInTheDocument();
   });
 
@@ -208,7 +208,7 @@ describe('ActionBubble', () => {
 
     // ASSERT
     expect(
-      await screen.findByText('0xf3...2266 funded this contract with 10.0 MATIC ($6.70) on January 3, 1970 at 2:33.')
+      await screen.findByText('0xf3...2266 funded this contract with 10.0 MATIC ($6.70) on January 3, 1970 at 7:33.')
     );
   });
 
@@ -223,7 +223,7 @@ describe('ActionBubble', () => {
     render(<ActionBubble action={{ ...action }} bounty={bounty} addresses={addresses} />);
 
     // ASSERT
-    expect(await screen.findByText('0xf3...2266 refunded a deposit of 10.0 MATIC ($6.70) on January 3, 1970 at 2:33.'));
+    expect(await screen.findByText('0xf3...2266 refunded a deposit of 10.0 MATIC ($6.70) on January 3, 1970 at 7:33.'));
   });
 
   it('should display multi claimed action message', async () => {
@@ -238,7 +238,7 @@ describe('ActionBubble', () => {
     render(<ActionBubble action={action} bounty={bounty} addresses={addresses} />);
 
     // ASSERT
-    expect(await screen.findByText('sample.eth made a claim on this contract on January 3, 1970 at 2:33.'));
+    expect(await screen.findByText('sample.eth made a claim on this contract on January 3, 1970 at 7:33.'));
   });
   it('should display single claimed action message', async () => {
     // ARRANGE
@@ -252,7 +252,7 @@ describe('ActionBubble', () => {
     render(<ActionBubble action={action} bounty={{ ...bounty, bountyType: '0' }} addresses={addresses} />);
 
     // ASSERT
-    expect(await screen.findByText('sample.eth claimed this contract on January 3, 1970 at 2:33.'));
+    expect(await screen.findByText('sample.eth claimed this contract on January 3, 1970 at 7:33.'));
   });
   it('should display closed action message', async () => {
     // ARRANGE
@@ -266,6 +266,6 @@ describe('ActionBubble', () => {
     render(<ActionBubble action={action} bounty={{ ...bounty, bountyType: '0' }} addresses={addresses} />);
 
     // ASSERT
-    expect(await screen.findByText('sample.eth closed this contract on January 3, 1970 at 2:33.'));
+    expect(await screen.findByText('sample.eth closed this contract on January 3, 1970 at 7:33.'));
   });
 });

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -47,13 +47,13 @@ const DepositCard = ({
             </div>
           )}
         </div>
-        {status === 'refundable' && (
+        
           <div className='flex flex-col space-y-3 w-44 pl-3 text-primary'>
+          {status === 'refundable' && (
             <ToolTipNew
               outerStyles='flex'
               hideToolTip={isOnCorrectNetwork}
               toolTipText={'Please switch to the correct network to refund this deposit.'}
-              customOffsets={[0, 46]}
             >
               <button
                 onClick={() => refundBounty(deposit.id)}
@@ -63,7 +63,7 @@ const DepositCard = ({
                 Refund
               </button>
             </ToolTipNew>
-
+          )}
             {expanded ? (
               <div className=' text-primary flex flex-col md:flex-row md:space-x-2 items-center'>
                 <div className='flex w-full input-field-big pl-4 justify-between'>
@@ -119,7 +119,6 @@ const DepositCard = ({
                 outerStyles='flex self-center'
                 hideToolTip={isOnCorrectNetwork}
                 toolTipText={'Please switch to the correct network to refund this deposit.'}
-                customOffsets={[0, 46]}
               >
                 <button
                   onClick={() => setExpanded(!expanded)}
@@ -131,7 +130,7 @@ const DepositCard = ({
               </ToolTipNew>
             )}
           </div>
-        )}
+        
       </div>
     </div>
   );

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -64,6 +64,7 @@ const DepositCard = ({
               </button>
             </ToolTipNew>
           )}
+          {status !== 'refunded' && <>
             {expanded ? (
               <div className=' text-primary flex flex-col md:flex-row md:space-x-2 items-center'>
                 <div className='flex w-full input-field-big pl-4 justify-between'>
@@ -128,7 +129,8 @@ const DepositCard = ({
                   Extend
                 </button>
               </ToolTipNew>
-            )}
+            )} </>
+            }
           </div>
         
       </div>

--- a/components/RefundBounty/RefundPage.js
+++ b/components/RefundBounty/RefundPage.js
@@ -195,10 +195,25 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                       return (
                         <div key={deposit.id}>
                           <DepositCard
-                            deposit={deposit}
-                            status='not-yet-refundable'
-                            bounty={bounty}
-                            refundBounty={refundBounty}
+                          deposit={deposit}
+                          status='not-yet-refundable'
+                          bounty={bounty}
+                          onDepositPeriodChanged={onDepositPeriodChanged}
+                          depositPeriodDays={depositPeriodDays[deposit.id]}
+                          extendBounty={() => {
+                            setConfirmationMessage(
+                              `You are about to extend the bounty at ${bounty.bountyAddress.substring(
+                                0,
+                                12
+                              )}...${bounty.bountyAddress.substring(32)} by ${depositPeriodDays[deposit.id]} ${
+                                depositPeriodDays[deposit.id] == 1 ? 'day' : 'days'
+                              }.	Are you sure you want to extend this deposit?`
+                            );
+                            setExtend(true);
+                            setApproveTransferState(CONFIRM);
+                            setShowApproveTransferModal(deposit.id);
+                          }}
+                          isOnCorrectNetwork={isOnCorrectNetwork}
                           />
                         </div>
                       );

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",
-		"test": "jest --watch",
+		"test": "TZ=UTC jest --watch",
 		"gen": "node services/ethers/mocks/abiToJavascriptClass.js",
 		"prepare-mumbai": "mustache constants/config/mumbai.json constants/polygon-mumbai.json.mustache > constants/polygon-mumbai.json && mustache constants/config/mumbai.json constants/polygon-mumbai-tokens.json.mustache > constants/polygon-mumbai-tokens.json",
 		"prepare-polygon": "mustache constants/config/mainnet.json constants/polygon-mainnet.json.mustache > constants/polygon-mainnet.json && mustache constants/config/mainnet.json constants/polygon-mainnet-tokens.json.mustache > constants/polygon-mainnet-tokens.json"


### PR DESCRIPTION
closes #674 
requires merging PRS: 
- https://github.com/OpenQDev/OpenQ-Graph/pull/3
- https://github.com/OpenQDev/OpenQ-Contracts/pull/77

Modified so that:
- extend button visible as long as deposit not refunded
- extends by x days after expiration date if deposit not yet expired
- extends by x days from now if already expired
- modifies RefundPage test to adapt to above changes
- adds UTC timezone to test script in package.json & modifies all tests for UTC timzone
- adds test for DepositCard