### PR TITLE
Re adds Split price contracts and updates names.

### DIFF
--- a/__tests__/Bounty/BountyCardDetails.test.js
+++ b/__tests__/Bounty/BountyCardDetails.test.js
@@ -6,48 +6,16 @@ import React from 'react';
 import { render, screen } from '../../test-utils';
 import BountyCardDetails from '../../components/Bounty/BountyCardDetails';
 import { waitFor } from '@testing-library/react';
-import mocks from '../../__mocks__/mock-server.json';
-import InitialState from '../../store/Store/InitialState';
 
 // WARNING If you change the mock data for issues you may need to change some
 // of this test's getByText invocations to getAllByText.
 describe('BountyCardDetails', () => {
-  const newBounties = mocks.bounties;
-  const issueData = InitialState.githubRepository.parseIssuesData(mocks.githubIssues);
-  const prismaContracts = mocks.prismaBounties;
-  const fullBounties = InitialState.utils.combineBounties(
-    newBounties,
-    issueData,
-    prismaContracts.bounties.bountyConnection.nodes
-  );
   const tokenValues = {
     tokenPrices: { '0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39': 0.67 },
     tokens: { '0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39': 8.040000000000001 },
     total: 8.04,
   };
 
-  const testRender = (bounty) => {
-    it('should render BountyDetails', async () => {
-      // Arrange
-      render(<BountyCardDetails bounty={bounty} address={bounty.bountyAddress} tokenValues={tokenValues} />);
-
-      // ASSERT
-      await waitFor(() => {
-        const usdValue = screen.queryAllByText(/\$\d+.\d+/);
-        expect(usdValue[0]).toBeInTheDocument();
-
-        if (bounty.id === 'I_kwDOGWnnz85LAu6g') {
-          expect(screen.getByText(/Update README/i)).toBeInTheDocument();
-        } else {
-          expect(screen.getByText(/No linked/i)).toBeInTheDocument();
-        }
-      });
-    });
-  };
-
-  fullBounties.forEach((bounty) => {
-    testRender(bounty);
-  });
   it('should display bubles in correct order', async () => {
     const bounty = {
       id: 'I_kwDOGWnnz85GjwA1',
@@ -209,21 +177,21 @@ describe('BountyCardDetails', () => {
 
       //gets actions individually
       const refundAction = screen.getByText(
-        /0xf3\.\.\.2266 refunded a deposit of 2\.0 DERC20 \(\$1\.34\) on September 7, 2022 at 10:08/i
+        /0xf3\.\.\.2266 refunded a deposit of 2\.0 DERC20 \(\$1\.34\) on September 7, 2022 at 14:08/i
       );
       const fundActionOne = screen.getByText(
-        /0xf3\.\.\.2266 funded this contract with 1\.0 MATIC \(\$0\.67\) on September 7, 2022 at 6:09/i
+        /0xf3\.\.\.2266 funded this contract with 1\.0 MATIC \(\$0\.67\) on September 7, 2022 at 10:09/i
       );
       const fundActionTwo = screen.getByText(
-        /funded this contract with 2\.0 DERC20 \(\$1\.34\) on September 7, 2022 at 6:09/i
+        /funded this contract with 2\.0 DERC20 \(\$1\.34\) on September 7, 2022 at 10:09/i
       );
       const fundActionThree = screen.getByText(
-        /funded this contract with 1\.0 LINK \(\$0\.67\) on September 7, 2022 at 6:09/i
+        /funded this contract with 1\.0 LINK \(\$0\.67\) on September 7, 2022 at 10:09/i
       );
       const mergeAction = screen.getByText(/FlacoJones merged linked pull request/i);
-      const closedAction = screen.getByText(/FlacoJones closed this issue on March 28, 2022 at 13:57/i);
+      const closedAction = screen.getByText(/FlacoJones closed this issue on March 28, 2022 at 17:57/i);
       const linkedAction = screen.getByText(/FlacoJones linked/i);
-      const mintedAction = screen.getByText(/0xf3\.\.\.2266 minted this contract on September 7, 2022 at 6:09/i);
+      const mintedAction = screen.getByText(/0xf3\.\.\.2266 minted this contract on September 7, 2022 at 10:09/i);
 
       //orders individual actions into a correctly ordered array.
       const orderedActions = [

--- a/__tests__/ContractWizard/ContractWizard.test.js
+++ b/__tests__/ContractWizard/ContractWizard.test.js
@@ -15,6 +15,7 @@ describe('ContractWizard', () => {
     // ACT
     await user.click(screen.getByText('No'));
     await user.click(screen.getByText('No'));
+    await user.click(screen.getByText('No'));
     expect(await screen.findByText(/we didn't find a suitable contract/i)).toBeInTheDocument();
     expect(screen.getByRole('link').href).toBe('https://discord.gg/puQVqEvVXn');
   });
@@ -26,12 +27,25 @@ describe('ContractWizard', () => {
 
     // ACT
     await user.click(screen.getByText('No'));
+    await user.click(screen.getByText('No'));
     await user.click(screen.getByText('Yes'));
     expect(screen.getByText(/Create a Contest Contract to send funds to any GitHub issue/i));
     expect(screen.getByText(/How many tiers/i));
   });
 
-  it('should open wizard and direct to atomic contract server', async () => {
+  it('should open wizard and direct to repating contract', async () => {
+    // ARRANGE
+    const user = userEvent.setup();
+    render(<ContractWizard wizardVisibility={true} />);
+
+    // ACT
+    await user.click(screen.getByText('No'));
+    await user.click(screen.getByText('Yes'));
+    expect(screen.getByText(/Deploy split price contract/i));
+    expect(screen.getByText(/Reward Split/i));
+  });
+
+  it('should open wizard and direct to atomic contract', async () => {
     // ARRANGE
     const user = userEvent.setup();
     render(<ContractWizard wizardVisibility={true} />);
@@ -39,6 +53,6 @@ describe('ContractWizard', () => {
     // ACT
     expect(screen.getByText(/Should only one person complete this task/i)).toBeInTheDocument();
     await user.click(screen.getByText('Yes'));
-    expect(screen.getByText(/Create an Atomic Contract to send funds to any GitHub issue/i));
+    expect(screen.getByText(/Create a Fixed Price Contract to send funds to any GitHub issue/i));
   });
 });

--- a/__tests__/Layout/Navlinks.test.js
+++ b/__tests__/Layout/Navlinks.test.js
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '../../test-utils';
+import Navlinks from '../../components/Layout/NavLinks';
+import nextRouter from 'next/router';
+
+describe('Navlinks', () => {
+  it('should open wizard and direct to discord server', async () => {
+    // ARRANGE
+    nextRouter.useRouter = jest.fn();
+    nextRouter.useRouter.mockImplementation(() => ({
+      query: { type: null },
+
+      prefetch: jest.fn(() => {
+        return { catch: jest.fn };
+      }),
+    }));
+
+    render(<Navlinks />);
+
+    // ACT
+    expect(await screen.findByText(/fixed price/i)).toBeInTheDocument();
+    expect(await screen.findByText(/explore/i)).toBeInTheDocument();
+    expect(await screen.findByText(/split price/i)).toBeInTheDocument();
+    expect(await screen.findByText(/contests/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/MintBounty/MintBountyButton.test.js
+++ b/__tests__/MintBounty/MintBountyButton.test.js
@@ -20,6 +20,7 @@ describe('MintBountyButton', () => {
     await user.click(mintBountyButton);
     await user.click(screen.getByText('No'));
     await user.click(screen.getByText('No'));
+    await user.click(screen.getByText('No'));
     expect(await screen.findByText(/we didn't find a suitable contract/i)).toBeInTheDocument();
     expect(screen.getByRole('link').href).toBe('https://discord.gg/puQVqEvVXn');
   });
@@ -32,6 +33,7 @@ describe('MintBountyButton', () => {
     // ACT
     const mintBountyButton = await screen.findByRole('button', { name: /New Contract/i });
     await user.click(mintBountyButton);
+    await user.click(screen.getByText('No'));
     await user.click(screen.getByText('No'));
     await user.click(screen.getByText('Yes'));
     expect(screen.getByText(/Create a Contest Contract to send funds to any GitHub issue/i));
@@ -48,6 +50,6 @@ describe('MintBountyButton', () => {
     await user.click(mintBountyButton);
     expect(screen.getByText(/Should only one person complete this task/i)).toBeInTheDocument();
     await user.click(screen.getByText('Yes'));
-    expect(screen.getByText(/Create an Atomic Contract to send funds to any GitHub issue/i));
+    expect(screen.getByText(/Create a Fixed Price Contract to send funds to any GitHub issue/i));
   });
 });

--- a/__tests__/MintBounty/MintBountyHeader.test.js
+++ b/__tests__/MintBounty/MintBountyHeader.test.js
@@ -9,9 +9,9 @@ import MintBountyHeader from '../../components/MintBounty/MintBountyHeader';
 describe('MintBountyHeader', () => {
   it('should display atomic header', () => {
     // ARRANGE
-    render(<MintBountyHeader category={'Atomic'} />);
+    render(<MintBountyHeader category={'Fixed Price'} />);
 
-    expect(screen.getByText(/Create an Atomic Contract to send funds to any GitHub issue/i)).toBeInTheDocument();
+    expect(screen.getByText(/Create a Fixed Price Contract to send funds to any GitHub issue/i)).toBeInTheDocument();
     // should not have null or undefined values
     const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
     expect(nullish).toHaveLength(0);
@@ -19,7 +19,7 @@ describe('MintBountyHeader', () => {
 
   it('should display repeatable header', () => {
     // ARRANGE
-    render(<MintBountyHeader category={'Repeating'} />);
+    render(<MintBountyHeader category={'Split Price'} />);
 
     expect(
       screen.getByText(/Pay out a fixed amount to any contributors who submit work to this bounty/i)

--- a/__tests__/MintBounty/MintBountyModal.test.js
+++ b/__tests__/MintBounty/MintBountyModal.test.js
@@ -106,8 +106,9 @@ const test = (issue, type) => {
 
       case '2':
         {
+          expect(await screen.findAllByText(/place winner/)).toHaveLength(3);
           await user.type(screen.getByLabelText(/tier/), '2');
-          expect(await screen.findAllByText(/place winner/)).toHaveLength(2);
+          expect(await screen.findAllByText(/place winner/)).toHaveLength(32);
 
           /**/
         }

--- a/__tests__/MintBounty/MintBountyModal.test.js
+++ b/__tests__/MintBounty/MintBountyModal.test.js
@@ -107,9 +107,7 @@ const test = (issue, type) => {
       case '2':
         {
           await user.type(screen.getByLabelText(/tier/), '2');
-          expect(screen.getByLabelText(/tiers/).value).toBe('2');
-          expect(await screen.findByText(/Weight per Tier/)).toBeInTheDocument();
-          expect(await screen.findAllByPlaceholderText(/winner/)).toHaveLength(2);
+          expect(await screen.findAllByText(/place winner/)).toHaveLength(2);
 
           /**/
         }

--- a/__tests__/MintBounty/SetTierValues.test.js
+++ b/__tests__/MintBounty/SetTierValues.test.js
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '../../test-utils';
+import nextRouter from 'next/router';
+import SetTierValues from '../../components/MintBounty/SetTierValues';
+import userEvent from '@testing-library/user-event';
+
+describe('SetTier', () => {
+  it('should display initial values for bar inputs', async () => {
+    // ARRANGE
+    nextRouter.useRouter = jest.fn();
+    nextRouter.useRouter.mockImplementation(() => ({
+      query: { type: null },
+
+      prefetch: jest.fn(() => {
+        return { catch: jest.fn };
+      }),
+    }));
+    const mockSum = jest.fn();
+    const mockEnabler = jest.fn();
+    const mockSetFinalVolumes = jest.fn();
+    render(
+      <SetTierValues
+        category={'Contest'}
+        sum={9}
+        setSum={mockSum}
+        setEnableContest={mockEnabler}
+        finalTierVolumes={['2', '3', '4']}
+        tierArr={['0', '1', '2']}
+        setFinalTierVolumes={mockSetFinalVolumes}
+        initialVolumes={['2', '3', '4']}
+      />
+    );
+
+    // ACT
+    expect(await screen.findByText(/you still need to allocate: 91/i)).toBeInTheDocument();
+    expect(screen.getByText('2%')).toBeInTheDocument();
+    expect(screen.getByText('3%')).toBeInTheDocument();
+    expect(screen.getByText('4%')).toBeInTheDocument();
+    expect(screen.getByText('9%')).toBeInTheDocument();
+  });
+
+  it('should display initial values for bar inputs', async () => {
+    // ARRANGE
+    nextRouter.useRouter = jest.fn();
+    nextRouter.useRouter.mockImplementation(() => ({
+      query: { type: null },
+
+      prefetch: jest.fn(() => {
+        return { catch: jest.fn };
+      }),
+    }));
+    const mockSum = jest.fn();
+    const mockEnabler = jest.fn();
+    const mockSetFinalVolumes = jest.fn();
+    render(
+      <SetTierValues
+        category={'Fixed Contest'}
+        sum={9}
+        setSum={mockSum}
+        setEnableContest={mockEnabler}
+        finalTierVolumes={['2', '3', '4']}
+        tierArr={['1', '2', '3']}
+        setFinalTierVolumes={mockSetFinalVolumes}
+        initialVolumes={['2', '3', '4']}
+      />
+    );
+
+    // ACT
+    expect(screen.getByPlaceholderText(/1st winner/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/2nd winner/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/3rd winner/i)).toBeInTheDocument();
+  });
+});
+it('should give choice for bar inputs or number inputs', async () => {
+  // ARRANGE
+  nextRouter.useRouter = jest.fn();
+  nextRouter.useRouter.mockImplementation(() => ({
+    query: { type: null },
+
+    prefetch: jest.fn(() => {
+      return { catch: jest.fn };
+    }),
+  }));
+  const mockSum = jest.fn();
+  const mockEnabler = jest.fn();
+  const mockSetFinalVolumes = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <SetTierValues
+      category={'Contest'}
+      sum={9}
+      setSum={mockSum}
+      setEnableContest={mockEnabler}
+      finalTierVolumes={['2', '3', '4']}
+      tierArr={['0', '1', '2']}
+      setFinalTierVolumes={mockSetFinalVolumes}
+      initialVolumes={['2', '3', '4']}
+    />
+  );
+
+  // ACT
+  expect(screen.getByText('2%')).toBeInTheDocument();
+  expect(screen.getByText('3%')).toBeInTheDocument();
+  expect(screen.getByText('4%')).toBeInTheDocument();
+  expect(screen.getByText('9%')).toBeInTheDocument();
+  const switchToText = screen.getByText(/text/i);
+  await user.click(switchToText);
+
+  expect(await screen.findByPlaceholderText(/1st winner/i)).toBeInTheDocument();
+  expect(await screen.findByPlaceholderText(/2nd winner/i)).toBeInTheDocument();
+  expect(await screen.findByPlaceholderText(/3rd winner/i)).toBeInTheDocument();
+  expect(switchToText).toBeInTheDocument();
+});

--- a/__tests__/MintBounty/TextTierInput.test.js
+++ b/__tests__/MintBounty/TextTierInput.test.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { render, screen } from '../../test-utils';
-import TierInput from '../../components/MintBounty/TierInput';
+import TextTierInput from '../../components/MintBounty/TextTierInput';
 import InitialState from '../../store/Store/InitialState';
 
 InitialState.openQClient.shouldSleep = 200;
@@ -12,9 +12,9 @@ const mockTierVolumeChange = jest.fn();
 describe('Tier Input', () => {
   it('should show tier selecter', async () => {
     // ARRANGE
-    render(<TierInput tier={2} tierVolumes={{ 2: 80 }} onTierVolumeChange={mockTierVolumeChange} />);
+    render(<TextTierInput tier={2} tierVolumes={{ 2: 80 }} onTierVolumeChange={mockTierVolumeChange} />);
 
     // ACT
-    expect(screen.getByText(/3rd place/)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/2nd winner/).value).toEqual('80');
   });
 });

--- a/__tests__/MintBounty/TierInput.test.js
+++ b/__tests__/MintBounty/TierInput.test.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import { render, screen } from '../../test-utils';
 import TierInput from '../../components/MintBounty/TierInput';
-import userEvent from '@testing-library/user-event';
 import InitialState from '../../store/Store/InitialState';
 
 InitialState.openQClient.shouldSleep = 200;
@@ -13,12 +12,9 @@ const mockTierVolumeChange = jest.fn();
 describe('MintBountyButton', () => {
   it('should open wizard and direct to discord server', async () => {
     // ARRANGE
-    const user = userEvent.setup();
-    render(<TierInput tier={2} tierVolume={80} onTierVolumeChange={mockTierVolumeChange} />);
+    render(<TierInput tier={2} tierVolumes={{ 2: 80 }} onTierVolumeChange={mockTierVolumeChange} />);
 
     // ACT
-    const tierInput = screen.getByRole('textbox');
-    await user.type(tierInput, 'hi');
-    expect(mockTierVolumeChange).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(/2nd place/).toBeInTheDocument());
   });
 });

--- a/__tests__/MintBounty/TierResults.test.js
+++ b/__tests__/MintBounty/TierResults.test.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { render, screen } from '../../test-utils';
-import TierInput from '../../components/MintBounty/TierInput';
+import TierResults from '../../components/MintBounty/TierResult';
 import InitialState from '../../store/Store/InitialState';
 
 InitialState.openQClient.shouldSleep = 200;
@@ -12,9 +12,9 @@ const mockTierVolumeChange = jest.fn();
 describe('Tier Input', () => {
   it('should show tier selecter', async () => {
     // ARRANGE
-    render(<TierInput tier={2} tierVolumes={{ 2: 80 }} onTierVolumeChange={mockTierVolumeChange} />);
+    render(<TierResults tier={2} finalTierVolumes={[20, 80]} onTierVolumeChange={mockTierVolumeChange} />);
 
     // ACT
-    expect(screen.getByText(/3rd place/)).toBeInTheDocument();
+    expect(screen.getByText(/%/)).toBeInTheDocument();
   });
 });

--- a/__tests__/RefundBounty/DepositCard.test.js
+++ b/__tests__/RefundBounty/DepositCard.test.js
@@ -1,123 +1,122 @@
 /**
  * @jest-environment jsdom
  */
- import React from 'react';
- import { render, screen } from '../../test-utils';
- import DepositCard from '../../components/RefundBounty/DepositCard';
- import InitialState from '../../store/Store/InitialState';
- 
- describe('DepositCard', () => {
-   const deposits = [
-       {
-         id: '0xbf3f0b23ed5abb06f6ea2bdc516729d30cd5e9731a7a31ef77ef5382488455b2',
-         refunded: false,
-         receiveTime: '1662395968',
-         tokenAddress: '0x0000000000000000000000000000000000000000',
-         expiration: '1',
-         volume: '23000000000000000000',
-         sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
-         __typename: 'Deposit',
-       },
-       {
-         id: '0x8f5c1c912b8ffca325a22eadb33d6d54fa8e85b3752f2392eb54ecc6dd24b1e1',
-         refunded: false,
-         receiveTime: '1662395948',
-         tokenAddress: '0x0000000000000000000000000000000000000000',
-         expiration: '2592000',
-         volume: '23000000000000000000',
-         sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
-         __typename: 'Deposit',
-       },
-       {
-         id: '0x9c5e530511dff239da2c1c1205649aaa24fe2cc797d583a162744f26d623726a',
-         refunded: false,
-         receiveTime: '1662395897',
-         tokenAddress: '0x0000000000000000000000000000000000000000',
-         expiration: '2592000',
-         volume: '23000000000000000000',
-         sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
-         __typename: 'Deposit',
-       },
-       {
-        id: '0xbf3f0b23ed5abb06f6ea2bdc516729d30cd5e9731a7a31ef77ef5382488455b2',
-        refunded: true,
-        receiveTime: '1662395968',
-        tokenAddress: '0x0000000000000000000000000000000000000000',
-        expiration: '1',
-        volume: '23000000000000000000',
-        refundTime: '1662407371',
-        sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
-        __typename: 'Deposit',
-      }
-     ];
-   const isoDate = 1662396272728;
-   const RealDate = Date;
-   global.Date = class extends RealDate {
-     constructor() {
-       super();
-       return new RealDate(isoDate);
-     }
-   };
- 
-   beforeEach(() => {
-     InitialState.openQClient.reset();
-   });
- 
-   const test = (deposit) => {
-     it('should render the volume and name of token', async () => {
-       // ARRANGE
-       render(<DepositCard deposit={deposit} />);
-       let heading = await screen.findByText(/23.00 MATIC/i);
- 
-       // ASSERT
-       expect(heading).toBeInTheDocument();
-     });
- 
-     it('should render refund and extend button when refundable', async () => {
-       // ARRANGE
-       render(<DepositCard deposit={deposit} status={'refundable'} />);
-       const refundBtn = await screen.findByRole('button', { name: /Refund/i });
-       const extendBtn = await screen.findByRole('button', { name: /Extend/i });
- 
-       // ASSERT
-       expect(refundBtn).toBeInTheDocument();
-       expect(extendBtn).toBeInTheDocument();
- 
-       // ASSERT
-       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
-       expect(nullish).toHaveLength(0);
-     });
-     it('should render times whether refundable or not', async () => {
-       // ARRANGE
-       render(<DepositCard deposit={deposit} />);
- 
-       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
-       // ASSERT
-       expect(nullish).toHaveLength(0);
-       if(deposit.refunded) {
+import React from 'react';
+import { render, screen } from '../../test-utils';
+import DepositCard from '../../components/RefundBounty/DepositCard';
+import InitialState from '../../store/Store/InitialState';
+
+describe('DepositCard', () => {
+  const deposits = [
+    {
+      id: '0xbf3f0b23ed5abb06f6ea2bdc516729d30cd5e9731a7a31ef77ef5382488455b2',
+      refunded: false,
+      receiveTime: '1662395968',
+      tokenAddress: '0x0000000000000000000000000000000000000000',
+      expiration: '1',
+      volume: '23000000000000000000',
+      sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+      __typename: 'Deposit',
+    },
+    {
+      id: '0x8f5c1c912b8ffca325a22eadb33d6d54fa8e85b3752f2392eb54ecc6dd24b1e1',
+      refunded: false,
+      receiveTime: '1662395948',
+      tokenAddress: '0x0000000000000000000000000000000000000000',
+      expiration: '2592000',
+      volume: '23000000000000000000',
+      sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+      __typename: 'Deposit',
+    },
+    {
+      id: '0x9c5e530511dff239da2c1c1205649aaa24fe2cc797d583a162744f26d623726a',
+      refunded: false,
+      receiveTime: '1662395897',
+      tokenAddress: '0x0000000000000000000000000000000000000000',
+      expiration: '2592000',
+      volume: '23000000000000000000',
+      sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+      __typename: 'Deposit',
+    },
+    {
+      id: '0xbf3f0b23ed5abb06f6ea2bdc516729d30cd5e9731a7a31ef77ef5382488455b2',
+      refunded: true,
+      receiveTime: '1662395968',
+      tokenAddress: '0x0000000000000000000000000000000000000000',
+      expiration: '1',
+      volume: '23000000000000000000',
+      refundTime: '1662407371',
+      sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+      __typename: 'Deposit',
+    },
+  ];
+  const isoDate = 1662396272728;
+  const RealDate = Date;
+  global.Date = class extends RealDate {
+    constructor() {
+      super();
+      return new RealDate(isoDate);
+    }
+  };
+
+  beforeEach(() => {
+    InitialState.openQClient.reset();
+  });
+
+  const test = (deposit) => {
+    it('should render the volume and name of token', async () => {
+      // ARRANGE
+      render(<DepositCard deposit={deposit} />);
+      let heading = await screen.findByText(/23.00 MATIC/i);
+
+      // ASSERT
+      expect(heading).toBeInTheDocument();
+    });
+
+    it('should render refund and extend button when refundable', async () => {
+      // ARRANGE
+      render(<DepositCard deposit={deposit} status={'refundable'} />);
+      const refundBtn = await screen.findByRole('button', { name: /Refund/i });
+      const extendBtn = await screen.findByRole('button', { name: /Extend/i });
+
+      // ASSERT
+      expect(refundBtn).toBeInTheDocument();
+      expect(extendBtn).toBeInTheDocument();
+
+      // ASSERT
+      const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+      expect(nullish).toHaveLength(0);
+    });
+    it('should render times whether refundable or not', async () => {
+      // ARRANGE
+      render(<DepositCard deposit={deposit} />);
+
+      const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+      // ASSERT
+      expect(nullish).toHaveLength(0);
+      if (deposit.refunded) {
         expect(screen.getByText(/Refunded on: September 5, 2022 at 16:44/)).toBeInTheDocument();
-       } else {
+      } else {
         expect(screen.getByText(/Refundable on: September 5, 2022 at 16:44/)).toBeInTheDocument();
-       }
-     });
- 
-     it('should render extend button when not refunded yet', async () => {
-       // ARRANGE
-       render(<DepositCard deposit={deposit} />);
-       const extendBtn = await screen.findByRole('button', { name: /Extend/i });
- 
-       // ASSERT
-       if(deposit.status !== 'refunded') {
+      }
+    });
+
+    it('should render extend button when not refunded yet', async () => {
+      // ARRANGE
+      render(<DepositCard deposit={deposit} />);
+      const extendBtn = await screen.findByRole('button', { name: /Extend/i });
+
+      // ASSERT
+      if (deposit.status !== 'refunded') {
         expect(extendBtn).toBeInTheDocument();
-       } else {
+      } else {
         expect(extendBtn).toHaveLength(0);
-       }
-       
-       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
-       expect(nullish).toHaveLength(0);
-     });
-   };
- 
-   deposits.forEach((deposit) => test(deposit));
- });
- 
+      }
+
+      const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+      expect(nullish).toHaveLength(0);
+    });
+  };
+
+  deposits.forEach((deposit) => test(deposit));
+});

--- a/components/Admin/AdminModal.js
+++ b/components/Admin/AdminModal.js
@@ -48,15 +48,15 @@ const AdminModal = ({ setModal, modal }) => {
   };
   const title = {
     ['Closed Contest']: 'Contest Closed!',
-    ['Closed Repeatable']: 'Repeatable Contract Closed!',
+    ['Closed Split Price']: 'Split Price Contract Closed!',
     Budget: 'Budget Updated!',
     Payout: 'Payout Updated!',
     PayoutSchedule: 'Payout Schedule Updated!',
     Error: modal.title,
   };
   const content = {
-    ['Closed Repeatable']:
-      'Repeatable contract closed, no further claims will be available through this contract. Check out the closing transaction with the link below:',
+    ['Closed Split Price']:
+      'Split Price contract closed, no further claims will be available through this contract. Check out the closing transaction with the link below:',
     ['Closed Contest']:
       'Contest closed, now contestants can cash out. Check out the closing transaction with the link below:',
     Budget: 'Budget has been updated. Check out your transaction with the link below:',

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -20,7 +20,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
     case '0':
       break;
     case '1':
-      category = 'Repeating';
+      category = 'Split Price';
       break;
     case '2':
       category = 'Contest';
@@ -224,7 +224,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
       const transaction = await appState.openQClient.closeOngoing(library, bounty.bountyId);
       setModal({
         transaction,
-        type: 'Closed Repeatable',
+        type: 'Closed Split Price',
       });
       setShowButton(false);
       refreshBounty();
@@ -358,12 +358,14 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                       Set Payout
                     </button>
 
-                    <h2 className='text-2xl text-[#f85149] border-b border-gray-700 pb-4'>Close Repeatable Contract</h2>
+                    <h2 className='text-2xl text-[#f85149] border-b border-gray-700 pb-4'>
+                      Close Split Price Contract
+                    </h2>
                     <div className='flex justify-between items-center gap-2'>
-                      Once you close this repeatable contract, there is no going back. Please be certain.
+                      Once you close this split price contract, there is no going back. Please be certain.
                     </div>
                     <button className='btn-danger' type='button' onClick={closeOngoing}>
-                      Close Repeatable Contract
+                      Close Split Price Contract
                     </button>
                   </>
                 ) : null}

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -264,67 +264,71 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                   Set New Budget
                 </button>
 
-                {bounty.bountyType == '2' ? (
+                {bounty.bountyType === '2' || bounty.bountyType === '3' ? (
                   <>
-                    <div className='flex flex-col items-center pb-2'>
-                      <div className='flex flex-col w-full md:w-full'>
-                        <div className='flex flex-col w-full items-start p-2 py-1 text-base pb-4'>
-                          <div className='flex items-center gap-2'>
-                            How many Tiers?
-                            <ToolTipNew
-                              mobileX={10}
-                              toolTipText={`How many people will be able to claim a prize? Don't exceed 100.`}
-                            >
-                              <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
-                                ?
+                    {bounty.bountyType === '2' && (
+                      <>
+                        <div className='flex flex-col items-center pb-2'>
+                          <div className='flex flex-col w-full md:w-full'>
+                            <div className='flex flex-col w-full items-start p-2 py-1 text-base pb-4'>
+                              <div className='flex items-center gap-2'>
+                                How many Tiers?
+                                <ToolTipNew
+                                  mobileX={10}
+                                  toolTipText={`How many people will be able to claim a prize? Don't exceed 100.`}
+                                >
+                                  <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
+                                    ?
+                                  </div>
+                                </ToolTipNew>
                               </div>
-                            </ToolTipNew>
-                          </div>
-                          <div className='flex-1 w-full mt-2'>
-                            <input
-                              className={'flex-1 input-field w-full'}
-                              id='name'
-                              placeholder='0'
-                              autoComplete='off'
-                              type='text'
-                              min='0'
-                              max='100'
-                              value={tier}
-                              onChange={(e) => onTierChange(e)}
+                              <div className='flex-1 w-full mt-2'>
+                                <input
+                                  className={'flex-1 input-field w-full'}
+                                  id='name'
+                                  placeholder='0'
+                                  autoComplete='off'
+                                  type='text'
+                                  min='0'
+                                  max='100'
+                                  value={tier}
+                                  onChange={(e) => onTierChange(e)}
+                                />
+                              </div>
+                            </div>
+                            <SetTierValues
+                              category={category}
+                              sum={sum}
+                              initialVolumes={bounty.payoutSchedule || []}
+                              finalTierVolumes={finalTierVolumes}
+                              setFinalTierVolumes={setFinalTierVolumes}
+                              setSum={setSum}
+                              tierArr={tierArr}
+                              setEnableContest={setEnableContest}
                             />
                           </div>
                         </div>
-                        <SetTierValues
-                          category={category}
-                          sum={sum}
-                          initialVolumes={bounty.payoutSchedule || []}
-                          finalTierVolumes={finalTierVolumes}
-                          setFinalTierVolumes={setFinalTierVolumes}
-                          setSum={setSum}
-                          tierArr={tierArr}
-                          setEnableContest={setEnableContest}
-                        />
-                      </div>
-                    </div>
-                    <ToolTipNew
-                      hideToolTip={(enableContest && isOnCorrectNetwork && account) || isLoading}
-                      toolTipText={
-                        account && isOnCorrectNetwork && !enableContest
-                          ? 'Please make sure the sum of tier percentages adds up to 100.'
-                          : isOnCorrectNetwork
-                          ? 'Connect your wallet to mint a bounty!'
-                          : 'Please switch to the correct network to mint a bounty.'
-                      }
-                    >
-                      <button
-                        className={`w-full btn-default ${enableContest ? 'cursor-pointer' : 'cursor-not-allowed'}`}
-                        type='button'
-                        onClick={setPayoutSchedule}
-                        disabled={!enableContest}
-                      >
-                        Set New Payout Schedule
-                      </button>
-                    </ToolTipNew>
+                        <ToolTipNew
+                          hideToolTip={(enableContest && isOnCorrectNetwork && account) || isLoading}
+                          toolTipText={
+                            account && isOnCorrectNetwork && !enableContest
+                              ? 'Please make sure the sum of tier percentages adds up to 100.'
+                              : isOnCorrectNetwork
+                              ? 'Connect your wallet to mint a bounty!'
+                              : 'Please switch to the correct network to mint a bounty.'
+                          }
+                        >
+                          <button
+                            className={`w-full btn-default ${enableContest ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+                            type='button'
+                            onClick={setPayoutSchedule}
+                            disabled={!enableContest}
+                          >
+                            Set New Payout Schedule
+                          </button>
+                        </ToolTipNew>
+                      </>
+                    )}
 
                     <h2 className='text-2xl text-[#f85149] border-b border-gray-700 pb-4'>Close Contract</h2>
                     <p className='flex items-center gap-2'>

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -172,7 +172,6 @@ const AdminPage = ({ bounty, refreshBounty }) => {
       });
     }
   }
-  console.log(finalTierVolumes);
   async function setPayoutSchedule() {
     try {
       setIsLoading(true);

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -8,9 +8,9 @@ import AdminModal from './AdminModal.js';
 import ToolTipNew from '../Utils/ToolTipNew';
 import TierInput from '../MintBounty/TierInput';
 import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
-import BountyMetadata from '../Bounty/BountyMetadata';
+import ClaimText from './ClaimText';
 
-const AdminPage = ({ bounty, refreshBounty, price, budget, split }) => {
+const AdminPage = ({ bounty, refreshBounty }) => {
   // Context
   const { library, account } = useWeb3();
   const [appState] = useContext(StoreContext);
@@ -246,11 +246,11 @@ const AdminPage = ({ bounty, refreshBounty, price, budget, split }) => {
 
   return (
     <>
-      {showButton && (
-        <div className='flex justify-between  w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
-          <div className='flex flex-1 flex-col space-y-8 sm:px-12 px-4 pt-4 pb-8 w-full max-w-[800px] justify-center'>
+      {showButton ? (
+        <>
+          <div className='flex flex-1 flex-col space-y-8 pt-4 pb-8 w-full max-w-[800px] justify-center'>
             <div className='flex flex-col space-y-2 items-center w-full md:border rounded-sm border-gray-700 text-primary pb-8'>
-              <h1 className='flex w-full text-3xl justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm'>
+              <h1 className='flex w-full text-2xl justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm'>
                 Settings
               </h1>
               <div className='flex flex-col space-y-5 w-full px-8 pt-2'>
@@ -397,16 +397,11 @@ const AdminPage = ({ bounty, refreshBounty, price, budget, split }) => {
               </div>
             </div>
           </div>
-          <BountyMetadata
-            bounty={bounty}
-            pricesOnly={true}
-            setInternalMenu={() => null}
-            price={price}
-            budget={budget}
-            split={split}
-          />
-        </div>
+        </>
+      ) : (
+        <ClaimText bounty={bounty} />
       )}
+
       {modal && <AdminModal setModal={setModal} modal={modal} />}
       {error && (
         <AdminModal

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -62,7 +62,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
       });
     } else return [];
   }, [bounty]);
-  const [tier, setTier] = useState(0);
+  const [tier, setTier] = useState(bounty.payoutSchedule.length);
   const [tierArr, setTierArr] = useState(initialTierArr);
   const [finalTierVolumes, setFinalTierVolumes] = useState(bounty.payoutSchedule || []);
 
@@ -100,21 +100,28 @@ const AdminPage = ({ bounty, refreshBounty }) => {
   // handle change in Payout for Contests
 
   function onTierChange(e) {
-    if (parseInt(e.target.value) >= 0) {
+    const newTier = e.target.value;
+    if (newTier >= 0) {
+      console.log(newTier);
       setTier(parseInt(e.target.value));
     }
-    if (parseInt(e.target.value) > 100) {
+    if (newTier > 100) {
+      console.log('exic');
       setTier('0');
     }
-    if (e.target.value === '') setTier('0');
-    setTierArr(
-      Array.from(
-        {
-          length: e.target.value,
-        },
-        (_, i) => i + 1
-      )
+    const newTierArr = Array.from(
+      {
+        length: e.target.value,
+      },
+      (_, i) => i
     );
+    setTierArr(newTierArr);
+
+    // removes final tier volumes
+    const newFinalTierVolumes = newTierArr.map((tier) => {
+      return finalTierVolumes[tier];
+    });
+    setFinalTierVolumes(newFinalTierVolumes);
   }
 
   // useEffect
@@ -290,7 +297,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                                   type='text'
                                   min='0'
                                   max='100'
-                                  value={tier}
+                                  defaultValue={tier}
                                   onChange={(e) => onTierChange(e)}
                                 />
                               </div>

--- a/components/Admin/ClaimText.js
+++ b/components/Admin/ClaimText.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import CopyAddressToClipboard from '../Copy/CopyAddressToClipboard';
+
+const ClaimText = ({ bounty }) => {
+  return (
+    <div className='col-span-3 space-y-4 p-4'>
+      <p>
+        {bounty.bountyType === '2' || bounty.bountyType === '3'
+          ? 'Decide the winner by commenting OpenQ-Tier-[1,2,3]-Winner on the winning pull request:'
+          : "Don't forget to add a closer comment for this bounty on your pull request :-)."}
+      </p>
+      <div>
+        {bounty.bountyType === '2' || bounty.bountyType === '3' ? (
+          bounty.payoutSchedule.map((elem, index) => {
+            return (
+              <CopyAddressToClipboard
+                key={index}
+                noClip={true}
+                data={`Closes #${bounty.number} OpenQ-Tier-${index + 1}-Winner`}
+              />
+            );
+          })
+        ) : (
+          <CopyAddressToClipboard noClip={true} data={`Closes #${bounty.number}`} />
+        )}
+      </div>
+    </div>
+  );
+};
+export default ClaimText;

--- a/components/Admin/ClaimText.js
+++ b/components/Admin/ClaimText.js
@@ -10,7 +10,7 @@ const ClaimText = ({ bounty }) => {
           : "Don't forget to add a closer comment for this bounty on your pull request :-)."}
       </p>
       <div>
-        {bounty.bountyType === '2' || bounty.bountyType === '3' ? (
+        {bounty.bountyType === '2' || (bounty.bountyType === '3' && bounty.payoutSchedule) ? (
           bounty.payoutSchedule.map((elem, index) => {
             return (
               <CopyAddressToClipboard

--- a/components/Bounty/BountyCardDetails.js
+++ b/components/Bounty/BountyCardDetails.js
@@ -1,20 +1,17 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 
 // Custom
 
 import ActionBubble from '../Utils/ActionBubble';
 import StoreContext from '../../store/Store/StoreContext';
-import BountyMetadata from './BountyMetadata.js';
 import useWeb3 from '../../hooks/useWeb3';
 import useEns from '../../hooks/useENS';
 
-const BountyCardDetails = ({ bounty, setInternalMenu, justMinted, tokenValues, budgetValues, split }) => {
+const BountyCardDetails = ({ bounty, justMinted, tokenValues }) => {
   const [appState] = useContext(StoreContext);
   const { account } = useWeb3();
   const [senderEnsName] = useEns(bounty?.issuer?.id);
   const sender = senderEnsName || bounty?.issuer?.id;
-  const price = tokenValues?.total;
-  const budget = budgetValues?.total;
   const prs = bounty.prs.map((pr) => {
     const referencedTime = new Date(pr.referencedAt).getTime() / 1000;
 
@@ -27,15 +24,11 @@ const BountyCardDetails = ({ bounty, setInternalMenu, justMinted, tokenValues, b
 
       return { ...pr, mergedTime };
     });
-  useEffect(() => {
-    console.log(bounty);
-  });
   const issueClosedEvents = bounty.closedEvents.map((event) => {
     const issueClosedTime = new Date(bounty.closedAt).getTime() / 1000;
 
     return { ...event, issueClosedTime };
   });
-  console.log(issueClosedEvents);
   const deposits = bounty.deposits || [];
   const refunds = bounty.refunds || [];
   let claimedEvent = [];
@@ -79,25 +72,22 @@ const BountyCardDetails = ({ bounty, setInternalMenu, justMinted, tokenValues, b
   );
 
   return (
-    <div className='flex w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
-      <div className='flex-1 pr-4 min-w-[260px]'>
-        {allActions.map((action, index) => (
-          <ActionBubble
-            address={action.sender?.id || action.claimant?.id || sender}
-            key={index}
-            bounty={bounty}
-            action={action}
-          />
-        ))}
+    <div className='flex-1 pr-4 min-w-[260px]'>
+      {allActions.map((action, index) => (
         <ActionBubble
-          addresses={addresses}
-          address={sender}
-          price={tokenValues?.total}
+          address={action.sender?.id || action.claimant?.id || sender}
+          key={index}
           bounty={bounty}
-          bodyHTML={bounty.bodyHTML}
+          action={action}
         />
-      </div>
-      <BountyMetadata bounty={bounty} setInternalMenu={setInternalMenu} price={price} budget={budget} split={split} />
+      ))}
+      <ActionBubble
+        addresses={addresses}
+        address={sender}
+        price={tokenValues?.total}
+        bounty={bounty}
+        bodyHTML={bounty.bodyHTML}
+      />
     </div>
   );
 };

--- a/components/Bounty/BountyHeading.js
+++ b/components/Bounty/BountyHeading.js
@@ -13,7 +13,7 @@ const BountyHeading = ({ bounty, price }) => {
   const marker = appState.utils.getBountyMarker(bounty, authState.login);
 
   return (
-    <div className='sm:px-8 px-4 w-full max-w-[1200px] pb-4'>
+    <div className='sm:px-8 px-4 w-full max-w-[1200px] pb-2'>
       <div className='pt-6 pb-2 w-full flex flex-wrap'>
         <h1 className='text-[32px] flex-1 leading-tight min-w-[240px]'>
           <span className='text-primary'>{bounty.title} </span>

--- a/components/Bounty/BountyHomepage.js
+++ b/components/Bounty/BountyHomepage.js
@@ -19,7 +19,11 @@ const BountyHomepage = ({
   contractToggle,
 }) => {
   const title =
-    category === 'learn2earn' ? 'Repeatable Contracts' : category === 'contest' ? 'Contests' : 'Atomic Contracts';
+    category === 'split-price'
+      ? 'Split Price Contracts'
+      : category === 'contest'
+      ? 'Contests'
+      : 'Fixed Price Contracts';
   // Render
   return (
     <div>

--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -8,7 +8,7 @@ import StoreContext from '../../store/Store/StoreContext';
 import TokenBalances from '../TokenBalances/TokenBalances';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
 
-const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split, pricesOnly }) => {
+const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
   const [appState] = useContext(StoreContext);
   const createPayout = (bounty) => {
     return bounty.payoutTokenVolume
@@ -98,7 +98,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split, pricesO
           </div>
         </li>
       ) : null}
-      {!pricesOnly && (
+      {bounty.assignees && (
         <>
           {bounty.assignees.length > 0 && (
             <li className='border-b border-web-gray py-3'>

--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -7,6 +7,7 @@ import CopyBountyAddress from './CopyBountyAddress';
 import StoreContext from '../../store/Store/StoreContext';
 import TokenBalances from '../TokenBalances/TokenBalances';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
+import PieChart from './PieChart';
 
 const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
   const [appState] = useContext(StoreContext);
@@ -98,6 +99,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
               );
             })}
           </div>
+          <PieChart payoutSchedule={bounty.payoutSchedule} />
         </li>
       ) : null}
       {bounty.assignees && (

--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -20,7 +20,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
   };
   const payoutBalances = useMemo(() => createPayout(bounty), [bounty]);
   const [payoutValues] = useGetTokenValues(payoutBalances);
-  let type = 'Atomic Contract';
+  let type = 'Fixed Price';
 
   switch (bounty.bountyType) {
     case '0':

--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -27,7 +27,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
       type = 'Fixed Price';
       break;
     case '1':
-      type = 'Multi';
+      type = 'Split Price';
       break;
     case '2':
       type = 'Contest';
@@ -39,10 +39,12 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
 
   return (
     <ul className='md:max-w-[300px] w-full md:pl-4'>
-      <li className='border-b border-web-gray py-3'>
-        <div className='text-xs font-semibold text-muted'>Type</div>
-        <div className='text-xs font-semibold text-primary leading-loose'>{type}</div>
-      </li>
+      {bounty.bountyType && (
+        <li className='border-b border-web-gray py-3'>
+          <div className='text-xs font-semibold text-muted'>Type</div>
+          <div className='text-xs font-semibold text-primary leading-loose'>{type}</div>
+        </li>
+      )}
 
       <li className='border-b border-web-gray py-3'>
         <div className='text-xs font-semibold text-muted'>TVL</div>

--- a/components/Bounty/CarouselBounty.js
+++ b/components/Bounty/CarouselBounty.js
@@ -69,7 +69,7 @@ const CarouselBounty = ({ bounty }) => {
                 ) : bounty.bountyType === '1' ? (
                   <span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
                     <PersonAddIcon />
-                    <div className='whitespace-nowrap'>Multi</div>
+                    <div className='whitespace-nowrap'>Split Price</div>
                   </span>
                 ) : (
                   (bounty.bountyType === '2' || bounty.bountyType === '3') && (

--- a/components/Bounty/PieChart.js
+++ b/components/Bounty/PieChart.js
@@ -1,0 +1,99 @@
+import React, { useEffect } from 'react';
+import * as d3 from 'd3';
+
+const PieChart = ({ payoutSchedule }) => {
+  const drawChart = () => {
+    const data = payoutSchedule.map((e) => parseInt(e));
+    console.log(data);
+    const margin = { top: 36, right: 30, bottom: 30, left: 30 };
+    const width = 280 - margin.left - margin.right;
+    const height = 280 - margin.top - margin.bottom;
+    const color = d3
+      .scaleOrdinal()
+      .domain(data.map((d) => d))
+      .range(
+        data.map((_, i) => {
+          const saturation = i % 2 ? 84 - i : 84 - i + 1;
+          const lightness = !(i % 2) ? 48 + i : 48 + i - 1;
+          const hue = 400 - i * 67;
+          return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+        })
+      );
+    d3.select('#pie-container>svg').remove();
+    const svg = d3
+      .select('#pie-container')
+      .append('svg')
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+      .attr('transform', 'translate(' + width / 2 + ',' + height / 2 + ')');
+    const pie = d3
+      .pie()
+      .sort(null)
+      .value((d) => d);
+    const arc = d3
+      .arc()
+      .innerRadius(0)
+      .outerRadius(Math.min(width, height) / 2 - 1)
+      .cornerRadius(0);
+    const arcs = pie(data);
+
+    const arcLabel = function () {
+      const radius = (Math.min(width, height) / 2) * 0.7;
+      return d3.arc().innerRadius(radius).outerRadius(radius);
+    };
+    svg
+      .append('g')
+      .attr('stroke', 'white')
+      .selectAll('path')
+      .data(arcs)
+      .enter()
+      .append('path')
+      .attr('fill', (d) => color(d))
+      .attr('d', arc)
+      .append('title')
+      .text((d) => `${d}%`);
+
+    svg
+      .append('g')
+      .attr('font-size', 12)
+      .attr('text-anchor', 'middle')
+      .selectAll('text')
+      .data(arcs)
+      .enter()
+      .append('text')
+      .attr('transform', (d) => {
+        return `translate(${arcLabel().centroid(d)})`;
+      })
+      .call((text) =>
+        text
+          .append('tspan')
+          .attr('y', '-0.4em')
+          .attr('font-weight', 'bold')
+          .text((_, index) => `Tier ${index + 1}`)
+          .call((text) =>
+            text
+              .append('tspan')
+              .attr('x', 0)
+              .attr('y', '0.7em')
+              .attr('fill-opacity', 0.7)
+              .text((d) => {
+                console.log(d);
+                return d.data.toString().concat('%');
+              })
+          )
+      );
+  };
+
+  useEffect(() => {
+    drawChart();
+  }, [payoutSchedule]);
+
+  return (
+    <li className='border-b border-web-gray py-3'>
+      <div id='pie-container'></div>
+    </li>
+  );
+};
+
+export default PieChart;

--- a/components/BountyCard/BountyCardLean.js
+++ b/components/BountyCard/BountyCardLean.js
@@ -157,7 +157,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
                   </span>
                 ) : bounty.bountyType === '1' ? (
                   <span className='font-semibold flex flex-end items-center content-center gap-1 w-max'>
-                    <div className='whitespace-nowrap'>Multi</div>
+                    <div className='whitespace-nowrap'>Split Price</div>
                     <PersonAddIcon />
                   </span>
                 ) : (

--- a/components/BountyClosed/BountyClosed.js
+++ b/components/BountyClosed/BountyClosed.js
@@ -16,7 +16,7 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
 
   //Render
   return (
-    <div className='flex w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
+    <div className='flex px-2 sm:px-0 flex-wrap flex-1  max-w-[1200px] pb-8'>
       <div className='flex-1 pr-4 min-w-[260px] space-y-4 pt-2'>
         <h2 className='flex text-3xl'>This contract is closed.</h2>
         <h3 className='flex text-2xl border-b border-gray-700 pb-4'>
@@ -34,43 +34,6 @@ const BountyClosed = ({ bounty, showTweetLink }) => {
               </a>
             </Link>
           </div>
-        </div>
-
-        <div className='flex flex-col border-b border-web-gray py-3 gap-2'>
-          {bounty?.prs?.some((pr) => pr.source['__typename'] === 'PullRequest' && pr.source.url) > 0 ? (
-            <>
-              <div className='font-semibold text-muted'>Linked Pull Requests</div>
-              {bounty.prs
-                .filter((pr) => {
-                  return pr.source['__typename'] === 'PullRequest' && pr.source.url;
-                })
-                .map((pr, index) => {
-                  if (pr.source['__typename'] === 'PullRequest' && pr.source.url) {
-                    return (
-                      <div className='flex gap-1 text-primary' key={index}>
-                        <Link href={pr.source.url}>
-                          <a target='_blank' className={'flex items-center gap-1 underline'}>
-                            <svg
-                              xmlns='http://www.w3.org/2000/svg'
-                              width='18'
-                              height='18'
-                              viewBox='0 0 24 24'
-                              fill='white'
-                            >
-                              <path d='M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z' />
-                            </svg>
-                            {pr.source.title}
-                          </a>
-                        </Link>
-                        <span>{pr.source.merged ? ' (merged)' : ' (not merged)'}</span>
-                      </div>
-                    );
-                  }
-                })}
-            </>
-          ) : (
-            <span className='font-semibold text-muted'>No linked pull requests</span>
-          )}
         </div>
 
         {showTweetLink && (

--- a/components/BountyList/BountyList.js
+++ b/components/BountyList/BountyList.js
@@ -121,7 +121,7 @@ const BountyList = ({
       case 'Contest':
         types = ['2', '3'];
         break;
-      case 'Multi':
+      case 'Split Price':
         types = ['1'];
         break;
     }
@@ -346,7 +346,7 @@ const BountyList = ({
               styles='whitespace-nowrap'
               width='36'
               title='Contract Type'
-              names={['Fixed Price', 'Contest', 'All']}
+              names={['Fixed Price', 'Split Price', 'Contest', 'All']}
               borderShape={'rounded-r-lg'}
             />
           )}

--- a/components/Claim/ClaimLoadingModal.js
+++ b/components/Claim/ClaimLoadingModal.js
@@ -147,7 +147,7 @@ const ClaimLoadingModal = ({
           </div>
         </div>
       </div>
-      <div onClick={() => updateModal()} className='bg-overlay absolute inset-0'></div>
+      <div onClick={() => updateModal()} className='bg-overlay z-40 absolute inset-0'></div>
     </div>
   );
 };

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -170,10 +170,15 @@ const ClaimOverview = ({ bounty }) => {
             {tokenAddresses.map((tokenAddress) => (
               <td key={tokenAddress} className='p-2 text-center'>
                 <td className='p-2 text-center' key={tokenAddress + 1}>
-                  1
+                  {parseFloat(totalDeposit(tokenAddress) - claimedVolume(tokenAddress)).toFixed(1)}
                 </td>
                 <td className='p-2 text-center' key={tokenAddress + 2}>
-                  2
+                  {(
+                    parseFloat(
+                      (totalDeposit(tokenAddress) - claimedVolume(tokenAddress)) / totalDeposit(tokenAddress)
+                    ) * 100
+                  ).toFixed(1)}{' '}
+                  %
                 </td>
                 <td className='p-2 text-center' key={tokenAddress + 3}>
                   3
@@ -210,10 +215,10 @@ const ClaimOverview = ({ bounty }) => {
             {tokenAddresses.map((tokenAddress) => (
               <td key={tokenAddress} className='p-2 text-center'>
                 <td className='p-2 text-center' key={tokenAddress + 1}>
-                  1
+                  {totalDeposit(tokenAddress)}
                 </td>
                 <td className='p-2 text-center' key={tokenAddress + 2}>
-                  2
+                  100 %
                 </td>
                 <td className='p-2 text-center' key={tokenAddress + 3}>
                   3

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -161,9 +161,57 @@ const ClaimOverview = ({ bounty }) => {
             ))}
             <td className='p-2'>Total</td>
           </tr>
-          <tr>Still Claimable</tr>
-          <tr className='italic'>of which currently refundable (plus link)</tr>
-          <tr>Total Deposited</tr>
+          <tr>
+            <td className='p-2'>Still Claimable</td>
+            {tokenAddresses.map((tokenAddress) => (
+              <td key={tokenAddress} className='p-2 text-center'>
+                <td className='p-2 text-center' key={tokenAddress + 1}>
+                  1
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 2}>
+                  2
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 3}>
+                  3
+                </td>
+              </td>
+            ))}
+            <td className='p-2'>Total</td>
+          </tr>
+          <tr className='italic'>
+            <td className='p-2'>of which currently refundable (tooltip and link for refund)</td>
+            {tokenAddresses.map((tokenAddress) => (
+              <td key={tokenAddress} className='p-2 text-center'>
+                <td className='p-2 text-center' key={tokenAddress + 1}>
+                  1
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 2}>
+                  2
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 3}>
+                  3
+                </td>
+              </td>
+            ))}
+            <td className='p-2'>Total</td>
+          </tr>
+          <tr className='font-bold items-center border-t border-gray-700'>
+            <td className='p-2'>Total Deposit</td>
+            {tokenAddresses.map((tokenAddress) => (
+              <td key={tokenAddress} className='p-2 text-center'>
+                <td className='p-2 text-center' key={tokenAddress + 1}>
+                  1
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 2}>
+                  2
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 3}>
+                  3
+                </td>
+              </td>
+            ))}
+            <td className='p-2'>Total</td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -85,22 +85,22 @@ const ClaimOverview = ({ bounty }) => {
       <table>
         <thead>
           <tr>
-            <th className='p-2'></th>
+            <th className='px-2 pb-2'></th>
             {tokenAddresses.map((token) => (
-              <th key={token} className='p-2'>
+              <th key={token} className='px-2 pb-2'>
                 {appState.tokenClient.getToken(token).symbol}
-                <div className='flex justify-between p-2'>
-                  <th className='p-2'>Vol</th>
-                  <th className='p-2'>%</th>
-                  <th className='p-2'>$</th>
+                <div className='flex justify-between px-2 pb-2'>
+                  <th className='px-2 pb-2'>Vol</th>
+                  <th className='px-2 pb-2'>%</th>
+                  <th className='px-2 pb-2'>$</th>
                 </div>
               </th>
             ))}
-            <th className='p-2'>
+            <th className='px-2 pb-2'>
               TOTAL
-              <div className='flex justify-between p-2'>
-                <th className='p-2'>%</th>
-                <th className='p-2'>$</th>
+              <div className='flex justify-between px-2 pb-2'>
+                <th className='px-2 pb-2'>%</th>
+                <th className='px-2 pb-2'>$</th>
               </div>
             </th>
           </tr>
@@ -109,27 +109,27 @@ const ClaimOverview = ({ bounty }) => {
           {claimants.map((claimant, index) => (
             <>
               <tr key={claimant}>
-                <td className='flex gap-4 items-center p-2' key={claimant}>
+                <td className='flex gap-4 items-center px-2 pb-2' key={claimant}>
                   <Jazzicon tooltipPosition={'-left-2'} size={36} address={claimant} />
                   <span>{claimantsShort[index]}</span>
                 </td>
                 {tokenAddresses.map((tokenAddress) => (
-                  <td key={tokenAddress} className='p-2 text-center'>
-                    <td className='p-2 text-center' key={tokenAddress + 1}>
+                  <td key={tokenAddress} className='px-2 pb-2 text-center'>
+                    <td className='px-2 pb-2 text-center' key={tokenAddress + 1}>
                       {bounty.payouts?.some((payout) => payout.closer.id == claimant) ? (
                         <>{claimantVolume(claimant, tokenAddress)}</>
                       ) : (
                         '0.0'
                       )}
                     </td>
-                    <td className='p-2 text-center' key={tokenAddress + 2}>
+                    <td className='px-2 pb-2 text-center' key={tokenAddress + 2}>
                       {bounty.payouts?.some((payout) => payout.closer.id == claimant) ? (
                         <>{claimantPercent(claimant, tokenAddress)} %</>
                       ) : (
                         '0.0'
                       )}
                     </td>
-                    <td className='p-2 text-center' key={tokenAddress + 3}>
+                    <td className='px-2 pb-2 text-center' key={tokenAddress + 3}>
                       {bounty.payouts?.some((payout) => payout.closer.id == claimant) ? (
                         <>{appState.utils.formatter.format(claimantBalances(claimant, tokenAddress))}</>
                       ) : (
@@ -138,41 +138,41 @@ const ClaimOverview = ({ bounty }) => {
                     </td>
                   </td>
                 ))}
-                <td className='flex justify-between p-2 text-center'>
-                  <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
-                  <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+                <td className='flex justify-between px-2 pb-2 text-center'>
+                  <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+                  <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
                 </td>
               </tr>
             </>
           ))}
           <tr className='font-bold items-center border-t border-gray-700'>
-            <td className='p-2'>SubTotal</td>
+            <td className='px-2 pb-2'>SubTotal</td>
             {tokenAddresses.map((tokenAddress) => (
-              <td key={tokenAddress} className='p-2 text-center'>
-                <td className='p-2 text-center' key={tokenAddress + 1}>
+              <td key={tokenAddress} className='px-2 pb-2 text-center'>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 1}>
                   {bounty.payouts ? <>{claimedVolume(tokenAddress)}</> : '0.0'}
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 2}>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 2}>
                   {bounty.payouts ? <>{(claimedVolume(tokenAddress) / totalDeposit(tokenAddress)) * 100} %</> : '0.0'}
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 3}>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 3}>
                   {bounty.payouts ? <>{claimedBalances(tokenAddress)}</> : '0.0'}
                 </td>
               </td>
             ))}
-            <td className='p-2 text-center'>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            <td className='px-2 pb-2 text-center'>
+              <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
             </td>
           </tr>
           <tr>
-            <td className='p-2'>Still Claimable</td>
+            <td className='px-2'>Still Claimable</td>
             {tokenAddresses.map((tokenAddress) => (
-              <td key={tokenAddress} className='p-2 text-center'>
-                <td className='p-2 text-center' key={tokenAddress + 1}>
+              <td key={tokenAddress} className='px-2 text-center'>
+                <td className='px-2 text-center' key={tokenAddress + 1}>
                   {parseFloat(totalDeposit(tokenAddress) - claimedVolume(tokenAddress)).toFixed(1)}
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 2}>
+                <td className='px-2 text-center' key={tokenAddress + 2}>
                   {(
                     parseFloat(
                       (totalDeposit(tokenAddress) - claimedVolume(tokenAddress)) / totalDeposit(tokenAddress)
@@ -180,54 +180,54 @@ const ClaimOverview = ({ bounty }) => {
                   ).toFixed(1)}{' '}
                   %
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 3}>
+                <td className='px-2 text-center' key={tokenAddress + 3}>
                   3
                 </td>
               </td>
             ))}
-            <td className='p-2 text-center'>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            <td className='px-2 text-center'>
+              <td className='px-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='px-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
             </td>
           </tr>
           <tr className='italic'>
-            <td className='p-2'>of which currently refundable</td>
+            <td className='px-2 pb-2'>of which currently refundable</td>
             {tokenAddresses.map((tokenAddress) => (
-              <td key={tokenAddress} className='p-2 text-center'>
-                <td className='p-2 text-center' key={tokenAddress + 1}>
+              <td key={tokenAddress} className='px-2 pb-2 text-center'>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 1}>
                   1
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 2}>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 2}>
                   2
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 3}>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 3}>
                   3
                 </td>
               </td>
             ))}
-            <td className='p-2 text-center'>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            <td className='px-2 pb-2 text-center'>
+              <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
             </td>
           </tr>
           <tr className='font-bold items-center border-t border-gray-700'>
-            <td className='p-2'>Total Deposit</td>
+            <td className='px-2 pb-2'>Total Deposit</td>
             {tokenAddresses.map((tokenAddress) => (
-              <td key={tokenAddress} className='p-2 text-center'>
-                <td className='p-2 text-center' key={tokenAddress + 1}>
+              <td key={tokenAddress} className='px-2 pb-2 text-center'>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 1}>
                   {totalDeposit(tokenAddress)}
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 2}>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 2}>
                   100 %
                 </td>
-                <td className='p-2 text-center' key={tokenAddress + 3}>
+                <td className='px-2 pb-2 text-center' key={tokenAddress + 3}>
                   3
                 </td>
               </td>
             ))}
-            <td className='p-2 text-center'>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
-              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            <td className='px-2 pb-2 text-center'>
+              <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
             </td>
           </tr>
         </tbody>

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -80,6 +80,26 @@ const ClaimOverview = ({ bounty }) => {
     return (claimantVolume(claimant, tokenAddress) / totalDeposit(tokenAddress)) * 100;
   };
 
+  const stillClaimable = (tokenAddress) => {
+    const getBalances = () => {
+      return bounty.bountyTokenBalances
+        ? bounty.bountyTokenBalances.filter((balances) => balances.tokenAddress == tokenAddress)
+        : null;
+    };
+    const balanceObj = useMemo(() => getBalances(), [tokenAddress]);
+    const [balanceValues] = useGetTokenValues(balanceObj);
+    return balanceValues?.total;
+  };
+
+  const totalDepositBalance = (tokenAddress) => {
+    const getBalances = () => {
+      return bounty.payouts ? bounty.payouts.filter((payout) => payout.tokenAddress == tokenAddress) : null;
+    };
+    const balanceObj = useMemo(() => getBalances(tokenAddress), [tokenAddress]);
+    const [balanceValues] = useGetTokenValues(balanceObj);
+    return balanceValues?.total + stillClaimable(tokenAddress);
+  };
+
   return (
     <div>
       <table>
@@ -138,7 +158,7 @@ const ClaimOverview = ({ bounty }) => {
                     </td>
                   </td>
                 ))}
-                <td className='flex justify-between px-2 pb-2 text-center'>
+                <td className='px-2 pb-2 text-center'>
                   <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
                   <td className='px-2 pb-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
                 </td>
@@ -150,13 +170,13 @@ const ClaimOverview = ({ bounty }) => {
             {tokenAddresses.map((tokenAddress) => (
               <td key={tokenAddress} className='px-2 pb-2 text-center'>
                 <td className='px-2 pb-2 text-center' key={tokenAddress + 1}>
-                  {bounty.payouts ? <>{claimedVolume(tokenAddress)}</> : '0.0'}
+                  {claimedVolume(tokenAddress)}
                 </td>
                 <td className='px-2 pb-2 text-center' key={tokenAddress + 2}>
-                  {bounty.payouts ? <>{(claimedVolume(tokenAddress) / totalDeposit(tokenAddress)) * 100} %</> : '0.0'}
+                  {(claimedVolume(tokenAddress) / totalDeposit(tokenAddress)) * 100} %
                 </td>
                 <td className='px-2 pb-2 text-center' key={tokenAddress + 3}>
-                  {bounty.payouts ? <>{claimedBalances(tokenAddress)}</> : '0.0'}
+                  {claimedBalances(tokenAddress)}
                 </td>
               </td>
             ))}
@@ -181,7 +201,7 @@ const ClaimOverview = ({ bounty }) => {
                   %
                 </td>
                 <td className='px-2 text-center' key={tokenAddress + 3}>
-                  3
+                  {appState.utils.formatter.format(stillClaimable(tokenAddress))}
                 </td>
               </td>
             ))}
@@ -221,7 +241,7 @@ const ClaimOverview = ({ bounty }) => {
                   100 %
                 </td>
                 <td className='px-2 pb-2 text-center' key={tokenAddress + 3}>
-                  3
+                  {appState.utils.formatter.format(totalDepositBalance(tokenAddress))}
                 </td>
               </td>
             ))}

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -1,0 +1,79 @@
+import React, { useContext } from 'react';
+import StoreContext from '../../store/Store/StoreContext';
+import Jazzicon from '../Utils/Jazzicon';
+import useEns from '../../hooks/useENS';
+
+// get bounty info
+// cols => bounty.deposits => list of token addresses (3 subcolumns => vol / % / $ value)
+// end of cols => sum col value in $ total
+// rows => bounty.payouts.closer.id (with jazzicon like AB) => payouts.volume per tokenAddress (and % total deposit & $ value)
+// subsum row
+// "rest" row => still available for claim
+// "total" value deposited
+
+// design => flexbox => 1 element left = list of claimants // then 1 component repeated per tokenAdress // 1 element right = sum
+// height of each fixed - middle with scroll // end fixed
+// bottom fixed
+// => or table react
+
+const ClaimOverview = ({ bounty }) => {
+  const [appState] = useContext(StoreContext);
+  const shortenAddress = (address) => {
+    if (!address) {
+      return '';
+    }
+    return `${address.slice(0, 4)}...${address.slice(38)}`;
+  };
+  const tokenAdresses = bounty.deposits
+    .map((deposit) => appState.tokenClient.getToken(deposit.tokenAddress).symbol)
+    .filter((itm, pos, self) => {
+      return self.indexOf(itm) == pos;
+    });
+  const claimants = bounty.payouts
+    .map((payout) => payout.closer.id)
+    .filter((itm, pos, self) => {
+      return self.indexOf(itm) == pos;
+    });
+  const claimantsShort = claimants.map((claimant) => {
+    const [claimantEnsName] = useEns(claimant);
+    return claimantEnsName || shortenAddress(claimant);
+  });
+
+  console.log(claimants);
+
+  return (
+    <div>
+      <table>
+        <thead>
+          <tr>
+            <th className='p-2'></th>
+            {tokenAdresses.map((token) => (
+              <th key={token} className='p-2'>
+                {token}
+              </th>
+            ))}
+            <th className='p-2'>Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {claimants.map((address, index) => (
+            <tr key={address}>
+              <td className='flex gap-4 items-center p-2' key={address}>
+                <Jazzicon tooltipPosition={'-left-2'} size={36} address={address} />
+                <span>{claimantsShort[index]}</span>
+              </td>
+              {tokenAdresses.map((item) => (
+                <td className='p-2' key={item}>
+                  {item}
+                </td>
+              ))}
+              <td className='p-2'>Total</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ClaimOverview;

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -5,14 +5,6 @@ import useEns from '../../hooks/useENS';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
 import { ethers } from 'ethers';
 
-// get bounty info
-// cols => bounty.deposits => list of token addresses (3 subcolumns => vol / % / $ value)
-// end of cols => sum col value in $ total
-// rows => bounty.payouts.closer.id (with jazzicon like AB) => payouts.volume per tokenAddress (and % total deposit & $ value)
-// subsum row
-// "rest" row => still available for claim
-// "total" value deposited
-
 const ClaimOverview = ({ bounty }) => {
   const [appState] = useContext(StoreContext);
   const shortenAddress = (address) => {
@@ -104,7 +96,13 @@ const ClaimOverview = ({ bounty }) => {
                 </div>
               </th>
             ))}
-            <th className='p-2'>Total</th>
+            <th className='p-2'>
+              TOTAL
+              <div className='flex justify-between p-2'>
+                <th className='p-2'>%</th>
+                <th className='p-2'>$</th>
+              </div>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -140,7 +138,10 @@ const ClaimOverview = ({ bounty }) => {
                     </td>
                   </td>
                 ))}
-                <td className='p-2'>Total</td>
+                <td className='flex justify-between p-2 text-center'>
+                  <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+                  <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+                </td>
               </tr>
             </>
           ))}
@@ -159,11 +160,71 @@ const ClaimOverview = ({ bounty }) => {
                 </td>
               </td>
             ))}
-            <td className='p-2'>Total</td>
+            <td className='p-2 text-center'>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            </td>
           </tr>
-          <tr>Still Claimable</tr>
-          <tr className='italic'>of which currently refundable (plus link)</tr>
-          <tr>Total Deposited</tr>
+          <tr>
+            <td className='p-2'>Still Claimable</td>
+            {tokenAddresses.map((tokenAddress) => (
+              <td key={tokenAddress} className='p-2 text-center'>
+                <td className='p-2 text-center' key={tokenAddress + 1}>
+                  1
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 2}>
+                  2
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 3}>
+                  3
+                </td>
+              </td>
+            ))}
+            <td className='p-2 text-center'>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            </td>
+          </tr>
+          <tr className='italic'>
+            <td className='p-2'>of which currently refundable</td>
+            {tokenAddresses.map((tokenAddress) => (
+              <td key={tokenAddress} className='p-2 text-center'>
+                <td className='p-2 text-center' key={tokenAddress + 1}>
+                  1
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 2}>
+                  2
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 3}>
+                  3
+                </td>
+              </td>
+            ))}
+            <td className='p-2 text-center'>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            </td>
+          </tr>
+          <tr className='font-bold items-center border-t border-gray-700'>
+            <td className='p-2'>Total Deposit</td>
+            {tokenAddresses.map((tokenAddress) => (
+              <td key={tokenAddress} className='p-2 text-center'>
+                <td className='p-2 text-center' key={tokenAddress + 1}>
+                  1
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 2}>
+                  2
+                </td>
+                <td className='p-2 text-center' key={tokenAddress + 3}>
+                  3
+                </td>
+              </td>
+            ))}
+            <td className='p-2 text-center'>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>OK</div> : '0.0'}</td>
+              <td className='p-2 text-center'>{bounty.payouts ? <div>BIS</div> : '0.0'}</td>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -19,9 +19,7 @@ import BountyClosed from '../BountyClosed/BountyClosed';
 import useEns from '../../hooks/useENS';
 import ToolTipNew from '../Utils/ToolTipNew';
 import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
-import CopyAddressToClipboard from '../Copy/CopyAddressToClipboard';
 import StoreContext from '../../store/Store/StoreContext';
-import ClaimOverview from './ClaimOverview';
 
 const ClaimPage = ({ bounty, refreshBounty }) => {
   const { url } = bounty;
@@ -131,13 +129,13 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
     // rewards are claimable
     return (
       <>
-        <ClaimOverview bounty={bounty} />
-        <div className='flex flex-1 px-12 pt-4 pb-8 w-full max-w-[1200px] justify-center'>
-          <div className='flex flex-col space-y-2 items-center md:border rounded-sm border-gray-700'>
+        {/* <ClaimOverview bounty={bounty} />*/}
+        <div className='flex flex-1 pt-4 pb-8 w-full max-w-[1200px] justify-center'>
+          <div className='flex flex-col w-full space-y-2 items-center content-center md:border rounded-sm border-gray-700'>
             <div className='flex w-full text-3xl text-primary justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm'>
               Claim Your Rewards
             </div>
-            <div className='flex flex-1 justify-center'>
+            <div className='flex flex-1 justify-center content-center items-center'>
               <div className='w-5/6 pb-4 min-w-min'>
                 <div className='flex flex-col gap-4 pt-4'>
                   {!authState.isAuthenticated ? (
@@ -145,31 +143,10 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
                       We noticed you are not signed into Github. You must sign to verify and claim an issue!
                     </div>
                   ) : null}
-                  <div className='col-span-3 space-y-4 p-4'>
-                    <p>
-                      {bounty.bountyType === '2' || bounty.bountyType === '3'
-                        ? 'Decide the winner by commenting OpenQ-Tier-[1,2,3]-Winner on the winning pull request:'
-                        : "Don't forget to add a closer comment for this bounty on your pull request :-)."}
-                    </p>
-                    <div>
-                      {bounty.bountyType === '2' || bounty.bountyType === '3' ? (
-                        bounty.payoutSchedule.map((elem, index) => {
-                          return (
-                            <CopyAddressToClipboard
-                              key={index}
-                              noClip={true}
-                              data={`Closes #${bounty.number} OpenQ-Tier-${index + 1}-Winner`}
-                            />
-                          );
-                        })
-                      ) : (
-                        <CopyAddressToClipboard noClip={true} data={`Closes #${bounty.number}`} />
-                      )}
-                    </div>
-                  </div>
 
                   <div className='flex flex-col space-y-5'>
                     <ToolTipNew
+                      groupStyles={'w-full'}
                       outerStyles='flex w-full items-center'
                       hideToolTip={account && isOnCorrectNetwork && authState.isAuthenticated}
                       toolTipText={
@@ -186,8 +163,8 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
                         type='submit'
                         className={
                           (isOnCorrectNetwork && authState.isAuthenticated) || !account
-                            ? 'btn-primary cursor-pointer w-full'
-                            : 'btn-default cursor-not-allowed w-full'
+                            ? 'btn-primary cursor-pointer w-full px-8 whitespace-nowrap'
+                            : 'btn-default cursor-not-allowed w-full px-8 whitespace-nowrap'
                         }
                         disabled={(!isOnCorrectNetwork || !authState.isAuthenticated) && account}
                         onClick={account ? () => setShowClaimLoadingModal(true) : connectWallet}

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -21,6 +21,7 @@ import ToolTipNew from '../Utils/ToolTipNew';
 import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
 import CopyAddressToClipboard from '../Copy/CopyAddressToClipboard';
 import StoreContext from '../../store/Store/StoreContext';
+import ClaimOverview from './ClaimOverview';
 
 const ClaimPage = ({ bounty, refreshBounty }) => {
   const { url } = bounty;
@@ -130,6 +131,7 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
     // rewards are claimable
     return (
       <>
+        <ClaimOverview bounty={bounty} />
         <div className='flex flex-1 px-12 pt-4 pb-8 w-full max-w-[1200px] justify-center'>
           <div className='flex flex-col space-y-2 items-center md:border rounded-sm border-gray-700'>
             <div className='flex w-full text-3xl text-primary justify-center px-12 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm'>

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -15,6 +15,7 @@ import useAuth from '../../hooks/useAuth';
 import AuthButton from '../Authentication/AuthButton';
 import useWeb3 from '../../hooks/useWeb3';
 import ClaimLoadingModal from './ClaimLoadingModal';
+import CopyAddressToClipboard from '../Copy/CopyAddressToClipboard';
 import BountyClosed from '../BountyClosed/BountyClosed';
 import useEns from '../../hooks/useENS';
 import ToolTipNew from '../Utils/ToolTipNew';
@@ -138,6 +139,11 @@ const ClaimPage = ({ bounty, refreshBounty }) => {
             <div className='flex flex-1 justify-center content-center items-center'>
               <div className='w-5/6 pb-4 min-w-min'>
                 <div className='flex flex-col gap-4 pt-4'>
+                  <p>
+                    {bounty.bountyType === '0' &&
+                      "Don't forget to add a closer comment for this bounty on your pull request :-)."}
+                    <CopyAddressToClipboard noClip={true} data={`Closes #${bounty.number}`} />
+                  </p>
                   {!authState.isAuthenticated ? (
                     <div className=' col-span-3 border border-gray-700 bg-[#21262d] rounded-sm p-4'>
                       We noticed you are not signed into Github. You must sign to verify and claim an issue!

--- a/components/ContractWizard/ContractWizard.js
+++ b/components/ContractWizard/ContractWizard.js
@@ -46,7 +46,9 @@ const ContractWizard = ({ wizardVisibility, refreshBounties }) => {
       wizardVisibility(false);
     }
   }, [mintModal]);
-
+  const handleTypeChange = () => {
+    setType(type + 1);
+  };
   return (
     <>
       {!mintModal ? (
@@ -56,9 +58,9 @@ const ContractWizard = ({ wizardVisibility, refreshBounties }) => {
               'flex justify-center items-start sm:items-center mx-4 overflow-x-hidden overflow-y-auto fixed inset-0 outline-none z-50 focus:outline-none p-10'
             }
           >
-            <div ref={modal} className='m-auto w-3/5 min-w-[320px] z-50 fixed top-40'>
+            <div ref={modal} className='m-auto w-3/5 min-w-[320px] max-w-screen-sm z-50 fixed top-40'>
               <div className='w-full rounded-sm flex flex-col bg-[#161B22] z-11 space-y-1'>
-                <div className='max-h-[70vh] w-full overflow-y-auto'>
+                <div className='max-h-[70vh] h-96 w-full overflow-y-auto'>
                   <div className='flex flex-col items-center justify-center p-5 pb-8 rounded-t'>
                     <h3 className='text-3xl text-center font-semibold'>Contract Wizard</h3>
                     <h3 className='text-2xl pt-2 w-5/6 text-center text-gray-300'>
@@ -73,14 +75,16 @@ const ContractWizard = ({ wizardVisibility, refreshBounties }) => {
                             ? 'Should only one person complete this task?'
                             : type == 1
                             ? 'Should several people be able to earn the same amount of money for this task? This contract is especially suitable for Learn 2 Earn.'
-                            : 'Do you want to create a contest and allow several people to earn money on this task? In this case you can set different weights and choose multiple winners.'}
+                            : type === 2
+                            ? 'Do you want to create a contest and allow several people to earn prizes? In this case you can set different weights and choose multiple winners.'
+                            : 'Do you want to create a contest and allow several people to earn fixed prizes? In this case you can set different weights and choose multiple winners.'}
                           <ToolTipNew
                             innerStyles={'whitespace-normal w-60'}
                             toolTipText={
                               type == 0
                                 ? 'Deploy an Fixed Price Contract to fund a single issue to be payed out to one submitter.'
                                 : type == 1
-                                ? 'Deploy a Repeating Contract, where several people can submit and claim the funds for the same issue.'
+                                ? 'Deploy a Split Price Contract, where several people can submit and claim the funds for the same issue.'
                                 : 'Do you want to create a contest and allow several people to earn money on this task? In this case you can set different weights and choose multiple winners.'
                             }
                           >
@@ -98,7 +102,7 @@ const ContractWizard = ({ wizardVisibility, refreshBounties }) => {
                               Yes
                             </button>
                             <button
-                              onClick={() => setType(type + 2)}
+                              onClick={handleTypeChange}
                               className='w-fit min-w-[80px] py-[5px] px-4 border-l-0 rounded-r-sm border whitespace-nowrap hover:bg-secondary-button hover:border-secondary-button border-web-gray'
                             >
                               No

--- a/components/ContractWizard/GetSupportModal.js
+++ b/components/ContractWizard/GetSupportModal.js
@@ -30,12 +30,12 @@ const GetSupportModal = ({ modalVisibility }) => {
           'flex justify-center items-start sm:items-center mx-4 overflow-x-hidden overflow-y-auto fixed inset-0 outline-none z-50 focus:outline-none p-10'
         }
       >
-        <div ref={modal} className='m-auto w-3/5 min-w-[320px] z-50 fixed top-40'>
-          <div className='w-full rounded-sm flex flex-col bg-[#161B22] z-11 space-y-1'>
+        <div ref={modal} className='m-auto w-3/5 min-w-[320px] max-w-screen-sm z-50 fixed top-40'>
+          <div className='w-full rounded-sm flex flex-col bg-[#161B22] z-11 space-y-1 md:h-96'>
             <div className='max-h-[70vh] w-full overflow-y-auto'>
               <div className='flex flex-col items-center justify-center p-5 pb-8 rounded-t space-y-4'>
                 <h3 className='text-3xl text-center font-semibold'>We didn't find a suitable contract</h3>
-                <h3 className='text-lg pt-8 w-5/6 text-center text-gray-300'>
+                <h3 className='text-lg pt-8 pb-8  w-5/6 text-center text-gray-300'>
                   Don't worry, you can help us and describe more precisely what kind of contract you want. If we don't
                   have this one yet, we'll be happy to get to it next. Join our Discord and write us in the support
                   channel or send us an email at riccardo@openq.dev

--- a/components/FundBounty/ApproveFundModal.js
+++ b/components/FundBounty/ApproveFundModal.js
@@ -185,7 +185,7 @@ const ApproveFundModal = ({
               </>
             ) : (
               <>
-                <div className='text-md gap-4 py-6 px-4 grid grid-cols-[1fr_1fr] w-full justify-between'>
+                <div className='text-md gap-4 py-6 pb-[68px] px-4 grid grid-cols-[1fr_1fr] w-full justify-between'>
                   <div className='w-4'>Funding</div>
                   <div className='flex flex-wrap justify-between w-[120px] gap-2'>
                     <Image
@@ -279,7 +279,7 @@ const ApproveFundModal = ({
           </div>
         </div>
       </div>
-      <div className='bg-overlay fixed inset-0'></div>
+      <div className='bg-overlay z-10 fixed inset-0'></div>
     </div>
   );
 };

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -64,7 +64,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
       ? 'btn-default w-full cursor-not-allowed'
       : 'btn-primary cursor-pointer'
   }`;
-  const fundButtonClasses = `flex flex-row w-full justify-center space-x-5 items-center  ${disableOrEnable}`;
+  const fundButtonClasses = `text-center px-8 items-center  ${disableOrEnable}`;
 
   function resetState() {
     setApproveTransferState(RESTING);
@@ -237,8 +237,8 @@ const FundPage = ({ bounty, refreshBounty }) => {
           <BountyClosed bounty={bounty} />
         </>
       ) : (
-        <div className='flex flex-1 sm:px-12 px-4 pt-4 pb-8 w-full max-w-[1200px] justify-center'>
-          <div className='flex flex-col space-y-5 pb-4 items-center md:border rounded-sm border-gray-700'>
+        <div className='flex flex-1 pt-4 pb-8 w-full max-w-[1200px] justify-center'>
+          <div className='flex flex-col w-full space-y-5 pb-4 items-center md:border rounded-sm border-gray-700'>
             <div className='flex text-3xl w-full text-primary justify-center px-16 py-4 md:bg-[#161b22] md:border-b border-gray-700 rounded-t-sm'>
               Escrow Funds{' '}
               {bounty.bountyType === '0'
@@ -258,6 +258,10 @@ const FundPage = ({ bounty, refreshBounty }) => {
               <div className='flex w-full input-field-big'>
                 <div className=' flex items-center gap-3 w-full text-primary md:whitespace-nowrap'>
                   <ToolTipNew
+                    relativePosition={'md:-left-12'}
+                    outerStyles={'-top-1'}
+                    groupStyles={''}
+                    innerStyles={'whitespace-normal md:w-96 sm:w-60 w-40  '}
                     toolTipText={
                       'This is the number of days that your deposit will be in escrow. After this many days, your deposit will be fully refundable if the bounty has still not been claimed.'
                     }
@@ -281,6 +285,10 @@ const FundPage = ({ bounty, refreshBounty }) => {
               </div>
 
               <ToolTipNew
+                relativePosition={'left-0'}
+                outerStyles={'-top-1'}
+                groupStyles={'w-min'}
+                innerStyles={'sm:w-40 w-40 md:w-auto whitespace-normal'}
                 hideToolTip={account && isOnCorrectNetwork && !loadingClosedOrZero}
                 toolTipText={
                   account && isOnCorrectNetwork && !(depositPeriodDays > 0)
@@ -298,7 +306,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
                   type='button'
                   onClick={account ? openFund : connectWallet}
                 >
-                  <div>{account ? buttonText : 'Connect Wallet'}</div>
+                  <div className='text-center w-full'>{account ? buttonText : 'Connect Wallet'}</div>
                   <div>
                     {approveTransferState != RESTING &&
                     approveTransferState != SUCCESS &&

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -37,16 +37,18 @@ const FundPage = ({ bounty, refreshBounty }) => {
   // Context
   const [appState, dispatch] = useContext(StoreContext);
   const { library, account } = useWeb3();
-
+  console.log(bounty.bountyType);
   // State
   const [token, setToken] = useState(zeroAddressMetadata);
   const bountyName =
-    bounty.bountyType == 0
+    bounty.bountyType === '0'
       ? 'Fixed Price'
-      : bounty.bountyType == 1
-      ? 'Repeatable Contract'
-      : bounty.bountyType == 2
+      : bounty.bountyType === '1'
+      ? 'Split Price Contract'
+      : bounty.bountyType === '2'
       ? 'Contest'
+      : bounty.bountyType === '3'
+      ? 'Fixed Contest'
       : 'Type Unknown';
 
   const closed = bounty.status == '1';
@@ -64,7 +66,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
       ? 'btn-default w-full cursor-not-allowed'
       : 'btn-primary cursor-pointer'
   }`;
-  const fundButtonClasses = `text-center px-8 items-center  ${disableOrEnable}`;
+  const fundButtonClasses = `text-center px-8 w-min items-center  ${disableOrEnable}`;
 
   function resetState() {
     setApproveTransferState(RESTING);
@@ -286,9 +288,9 @@ const FundPage = ({ bounty, refreshBounty }) => {
 
               <ToolTipNew
                 relativePosition={'left-0'}
-                outerStyles={'-top-1'}
+                outerStyles={'-top-1 '}
                 groupStyles={'w-min'}
-                innerStyles={'sm:w-40 w-40 md:w-auto whitespace-normal'}
+                innerStyles={'sm:w-40 w-0 md:w-60 whitespace-normal'}
                 hideToolTip={account && isOnCorrectNetwork && !loadingClosedOrZero}
                 toolTipText={
                   account && isOnCorrectNetwork && !(depositPeriodDays > 0)
@@ -301,7 +303,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
                 }
               >
                 <button
-                  className={fundButtonClasses}
+                  className={`${fundButtonClasses} py-1.5`}
                   disabled={(loadingClosedOrZero || !isOnCorrectNetwork) && account}
                   type='button'
                   onClick={account ? openFund : connectWallet}

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -37,7 +37,6 @@ const FundPage = ({ bounty, refreshBounty }) => {
   // Context
   const [appState, dispatch] = useContext(StoreContext);
   const { library, account } = useWeb3();
-  console.log(bounty.bountyType);
   // State
   const [token, setToken] = useState(zeroAddressMetadata);
   const bountyName =

--- a/components/FundBounty/SearchTokens/TokenSearch.js
+++ b/components/FundBounty/SearchTokens/TokenSearch.js
@@ -6,7 +6,7 @@ import { XIcon } from '@primer/octicons-react';
 import StoreContext from '../../../store/Store/StoreContext';
 import Image from 'next/image';
 
-const TokenSearch = ({ token, onCurrencySelect, stream, setShowTokenSearch }) => {
+const TokenSearch = ({ token, onCurrencySelect, stream, setShowTokenSearch, alone }) => {
   const [showListManager, setShowListManager] = useState(true);
   const [tokenSearchTerm, setTokenSearchTerm] = useState();
   const [lists, setLists] = useState({
@@ -17,11 +17,12 @@ const TokenSearch = ({ token, onCurrencySelect, stream, setShowTokenSearch }) =>
   const [customTokens, setCustomTokens] = useState([]);
   const [polygonTokens, setPolygonTokens] = useState([]);
   const [openQTokens, setOpenQTokens] = useState([]);
-  const [showStreamTokenSearch, setShowStreamTokenSearch] = useState(!stream);
+  const [showStreamTokenSearch, setShowStreamTokenSearch] = useState(false);
   const handleShowSearch = (bool) => {
-    if (stream) {
+    if (stream || alone) {
       setShowStreamTokenSearch(bool);
-    } else {
+    }
+    if (alone || !stream) {
       setShowTokenSearch(bool);
     }
   };
@@ -47,7 +48,7 @@ const TokenSearch = ({ token, onCurrencySelect, stream, setShowTokenSearch }) =>
     <div className='justify-self-end'>
       <div>
         <button
-          className='flex flex-row items-center space-x-1 py-2 drop-shadow-lg border border-web-gray rounded-sm p-2 pr-2'
+          className={`flex flex-row items-center space-x-1 py-2 drop-shadow-lg border border-web-gray rounded-sm p-2 pr-2 `}
           onClick={() => handleShowSearch(true)}
         >
           <div className='flex flex-row space-x-5 items-center justify-center'>
@@ -73,10 +74,12 @@ const TokenSearch = ({ token, onCurrencySelect, stream, setShowTokenSearch }) =>
           </div>
         </button>
       </div>
-      {(!stream || showStreamTokenSearch) && (
+      {((!stream && !alone) || showStreamTokenSearch) && (
         <div
           onClick={handleOutsideClick}
-          className='justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 left-20 z-50 outline-none focus:outline-none'
+          className={`justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 left-20 z-50 outline-none focus:outline-none
+          ${showStreamTokenSearch && 'visible'}
+          `}
         >
           <div className='w-5/6 max-w-md'>
             {' '}
@@ -130,7 +133,7 @@ const TokenSearch = ({ token, onCurrencySelect, stream, setShowTokenSearch }) =>
                   lists={lists}
                 />
               )}
-              {!stream && (
+              {!stream && !alone && (
                 <button
                   className='btn-default p-2 m-2'
                   onClick={(e) => {
@@ -145,7 +148,7 @@ const TokenSearch = ({ token, onCurrencySelect, stream, setShowTokenSearch }) =>
           </div>
         </div>
       )}
-      {!stream && <div className='fixed inset-0 z-10 bg-overlay'></div>}
+      {!stream && !alone && <div className='fixed inset-0 z-10 bg-overlay'></div>}
     </div>
   );
 };

--- a/components/Layout/NavLinks.js
+++ b/components/Layout/NavLinks.js
@@ -12,6 +12,9 @@ const NavLinks = () => {
       <Link href={'/fixed-price'}>
         <a className={`nav-link $ ${router.asPath === '/fixed-price' && 'text-white'}`}>Fixed Price</a>
       </Link>
+      <Link href={'/split-price'}>
+        <a className={`nav-link $ ${router.asPath === '/split-price' && 'text-white'}`}>Split Price</a>
+      </Link>
 
       <Link href={'/contests'}>
         <a className={`nav-link $ ${router.asPath === '/contests' && 'text-white'}`}>Contests</a>

--- a/components/MintBounty/MintBountyHeader.js
+++ b/components/MintBounty/MintBountyHeader.js
@@ -5,9 +5,9 @@ export default function MintBountyHeader({ category }) {
     <div className='flex flex-col items-center justify-center p-5 pb-3 rounded-t'>
       <h3 className='text-3xl text-center font-semibold'>Deploy {category} Contract</h3>
       <h3 className='text-2xl pt-2 text-center text-gray-300'>
-        {category === 'Repeating'
+        {category === 'Split Price'
           ? 'Pay out a fixed amount to any contributors who submit work to this bounty, as many times as you like'
-          : `Create a${category === 'Atomic' ? 'n' : ''} ${category} Contract to send funds to any GitHub issue`}
+          : `Create a${category === 'Fixed price' ? 'n' : ''} ${category} Contract to send funds to any GitHub issue`}
       </h3>
     </div>
   );

--- a/components/MintBounty/MintBountyInput.js
+++ b/components/MintBounty/MintBountyInput.js
@@ -13,7 +13,7 @@ export default function MintBountyInput({ setIssueUrl, issueData, isValidUrl, ur
         <div className='flex items-center gap-2'>
           Enter GitHub Issue URL
           <ToolTipNew mobileX={10} toolTipText={'Enter the link to the GitHub issue you would like to fund.'}>
-            <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
+            <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 text-sm box-content text-center font-bold text-primary'>
               ?
             </div>
           </ToolTipNew>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -268,7 +268,6 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
 
     setTierVolumes(newTierVolumes);
   }
-  console.log(tierArr);
   const handleGoalChange = (goalVolume) => {
     appState.utils.updateVolume(goalVolume, setGoalVolume);
   };

--- a/components/MintBounty/MintBountyModalButton.js
+++ b/components/MintBounty/MintBountyModalButton.js
@@ -3,7 +3,7 @@ import LoadingIcon from '../Loading/ButtonLoadingIcon';
 
 export default function MintBountyModalButton({ enableMint, transactionPending, mintBounty, account }) {
   return (
-    <div className='flex flex-row w-full justify-center'>
+    <div className='flex flex-row w-full h-[38px] justify-center'>
       <button
         className={`flex w-full items-center justify-center ${
           enableMint ? 'btn-primary cursor-pointer' : 'btn-primary cursor-not-allowed'

--- a/components/MintBounty/SetTierValues.js
+++ b/components/MintBounty/SetTierValues.js
@@ -1,0 +1,108 @@
+import React, { useState, useEffect } from 'react';
+import ToolTipNew from '../Utils/ToolTipNew';
+import TierInput from './TierInput';
+import TextTierInput from './TextTierInput';
+import TierResult from './TierResult';
+
+const SetTierValues = ({
+  category,
+  sum,
+  setSum,
+  tierArr,
+  setEnableContest,
+  finalTierVolumes,
+  setFinalTierVolumes,
+  initialVolumes,
+}) => {
+  const initialNumberVolumes = initialVolumes.map((elem) => parseInt(elem));
+  const [tierVolumes, setTierVolumes] = useState(initialNumberVolumes);
+  const [fixedTierVolumes, setFixedTierVolumes] = useState({});
+
+  function onFixedTierChange(e, localTierVolumes) {
+    if (parseInt(e.target.value) >= 0) {
+      setFixedTierVolumes({
+        ...localTierVolumes,
+        [e.name]: parseInt(e.target.value),
+      });
+    }
+    if (parseInt(e.target.value) === '' || !Number(e.target.value) || parseInt(e.target.value) > 100) {
+      setFixedTierVolumes({
+        ...localTierVolumes,
+        [e.name]: parseInt(e.target.value),
+      });
+    }
+  }
+  useEffect(() => {
+    setFinalTierVolumes(Object.values(tierVolumes));
+  }, [tierVolumes]);
+  useEffect(() => {
+    if (finalTierVolumes.length) {
+      setSum(finalTierVolumes.reduce((a, b) => a + b));
+    }
+
+    if (sum == 100 || category === 'Fixed Contest') {
+      setEnableContest(true);
+    }
+  }, [finalTierVolumes]);
+
+  const onTierVolumeChange = (e, localTierVolumes) => {
+    if (parseInt(e.target.value) >= 0) {
+      setTierVolumes({
+        ...localTierVolumes,
+        [e.name]: parseInt(e.target.value),
+      });
+    }
+    if (parseInt(e.target.value) === '' || !Number(e.target.value) || parseInt(e.target.value) > 100) {
+      setTierVolumes({
+        ...localTierVolumes,
+        [e.name]: parseInt(e.target.value),
+      });
+    }
+  };
+  return (
+    <>
+      {category === 'Contest' ? (
+        <div className='flex flex-col w-full items-start p-2 py-1 pb-0 text-base'>
+          <div className='flex items-center gap-2 '>
+            Weight per Tier (%)
+            <ToolTipNew mobileX={10} toolTipText={'How much % of the total will each winner earn?'}>
+              <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 text-sm box-content text-center font-bold text-primary'>
+                ?
+              </div>
+            </ToolTipNew>
+          </div>
+          {sum > 100 ? (
+            <span className='text-sm my-2 pb-2 text-[#f85149]'>The sum can not be more than 100%!</span>
+          ) : sum === 100 ? (
+            <span className='text-sm my-2 pb-2'>Sum is 100, now you can mint.</span>
+          ) : (
+            <span className='text-sm my-2 pb-2'>
+              For the sum to add up to 100, you still need to allocate: {100 - sum} %
+            </span>
+          )}
+          <div className=' w-full mx-h-60 overflow-y-auto overflow-x-hidden'>
+            {tierArr.map((t) => {
+              return (
+                <div key={t}>
+                  <TierInput tier={t} tierVolumes={tierVolumes} onTierVolumeChange={onTierVolumeChange} />
+                </div>
+              );
+            })}
+          </div>
+          <TierResult sum={sum} finalTierVolumes={finalTierVolumes} />
+        </div>
+      ) : (
+        <div className='max-h-40 w-full overflow-y-auto overflow-x-hidden'>
+          {tierArr.map((t) => {
+            return (
+              <div key={t}>
+                <TextTierInput tier={t} tierVolumes={fixedTierVolumes} onTierVolumeChange={onFixedTierChange} />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+};
+export default SetTierValues;

--- a/components/MintBounty/SetTierValues.js
+++ b/components/MintBounty/SetTierValues.js
@@ -3,6 +3,7 @@ import ToolTipNew from '../Utils/ToolTipNew';
 import TierInput from './TierInput';
 import TextTierInput from './TextTierInput';
 import TierResult from './TierResult';
+import SmallToggle from '../Utils/SmallToggle';
 
 const SetTierValues = ({
   category,
@@ -17,6 +18,7 @@ const SetTierValues = ({
   const initialNumberVolumes = initialVolumes.map((elem) => parseInt(elem));
   const [tierVolumes, setTierVolumes] = useState(initialNumberVolumes);
   const [fixedTierVolumes, setFixedTierVolumes] = useState({});
+  const [toggleVal, setToggleVal] = useState('Visual');
 
   function onFixedTierChange(e, localTierVolumes) {
     if (parseInt(e.target.value) >= 0) {
@@ -59,11 +61,22 @@ const SetTierValues = ({
       });
     }
   };
+  const handleToggle = () => {
+    if (toggleVal === 'Visual') {
+      setToggleVal('Text');
+      setTierVolumes({});
+      setSum(0);
+      setFinalTierVolumes([]);
+    } else {
+      setToggleVal('Visual');
+      setTierVolumes({ 0: 1, 1: 1, 2: 1 });
+    }
+  };
   return (
     <>
       {category === 'Contest' ? (
-        <div className='flex flex-col w-full items-start p-2 py-1 pb-0 text-base'>
-          <div className='flex items-center gap-2 '>
+        <div className='flex flex-col gap-2 w-full items-start p-2 py-1 pb-0 text-base'>
+          <div className='flex items-center gap-2'>
             Weight per Tier (%)
             <ToolTipNew mobileX={10} toolTipText={'How much % of the total will each winner earn?'}>
               <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 text-sm box-content text-center font-bold text-primary'>
@@ -71,24 +84,40 @@ const SetTierValues = ({
               </div>
             </ToolTipNew>
           </div>
+          <SmallToggle
+            toggleVal={toggleVal}
+            className={' ml-4 '}
+            toggleFunc={handleToggle}
+            names={['Visual', 'Text']}
+          />
           {sum > 100 ? (
-            <span className='text-sm my-2 pb-2 text-[#f85149]'>The sum can not be more than 100%!</span>
+            <span className='text-sm  text-[#f85149]'>The sum can not be more than 100%!</span>
           ) : sum === 100 ? (
-            <span className='text-sm my-2 pb-2'>Sum is 100, now you can mint.</span>
+            <span className='text-sm '>Sum is 100, now you can mint.</span>
           ) : (
-            <span className='text-sm my-2 pb-2'>
-              For the sum to add up to 100, you still need to allocate: {100 - sum} %
-            </span>
+            <span className='text-sm'>For the sum to add up to 100, you still need to allocate: {100 - sum} %</span>
           )}
-          <div className=' w-full mx-h-60 overflow-y-auto overflow-x-hidden'>
-            {tierArr.map((t) => {
-              return (
-                <div key={t}>
-                  <TierInput tier={t} tierVolumes={tierVolumes} onTierVolumeChange={onTierVolumeChange} />
-                </div>
-              );
-            })}
-          </div>
+          {toggleVal === 'Visual' ? (
+            <div className=' w-full mx-h-60 overflow-y-auto overflow-x-hidden'>
+              {tierArr.map((t) => {
+                return (
+                  <div key={t}>
+                    <TierInput tier={t} tierVolumes={tierVolumes} onTierVolumeChange={onTierVolumeChange} />
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className='max-h-40 w-full overflow-y-auto overflow-x-hidden'>
+              {tierArr.map((t, i) => {
+                return (
+                  <div key={i}>
+                    <TextTierInput tier={i + 1} tierVolumes={tierVolumes} onTierVolumeChange={onTierVolumeChange} />
+                  </div>
+                );
+              })}
+            </div>
+          )}
           <TierResult sum={sum} finalTierVolumes={finalTierVolumes} />
         </div>
       ) : (

--- a/components/MintBounty/TextTierInput.js
+++ b/components/MintBounty/TextTierInput.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState, useContext } from 'react';
+import StoreContext from '../../store/Store/StoreContext';
+
+const TextTierInput = ({ tier, tierVolumes, onTierVolumeChange, style }) => {
+  // State
+  const [suffix, setSuffix] = useState();
+  const [appState] = useContext(StoreContext);
+
+  useEffect(() => {
+    setSuffix(appState.utils.handleSuffix(tier));
+  }, []);
+
+  const handleChange = (value, tierVolumes) => {
+    const passedValue = parseInt(value) || 0;
+    onTierVolumeChange(
+      {
+        name: tier,
+
+        target: {
+          value: passedValue,
+        },
+      },
+      tierVolumes
+    );
+  };
+  return (
+    <div className={`flex-1 w-11/12 mb-1  ml-4 ${style}`}>
+      <input
+        name={tier}
+        id='tier-volume'
+        autoComplete='off'
+        placeholder={`${suffix} winner`}
+        value={tierVolumes[tier] || ''}
+        onChange={(e) => handleChange(e.target.value, tierVolumes)}
+        className='input-field w-full number'
+      />
+    </div>
+  );
+};
+
+export default TextTierInput;

--- a/components/MintBounty/TierInput.js
+++ b/components/MintBounty/TierInput.js
@@ -85,7 +85,7 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
               transformOrigin: 'left center',
               backgroundColor: `hsl(${hue}, ${saturation}%, ${lightness}%)`,
             }}
-            data-testId={'tierInput'}
+            data-testid={'tierInput'}
             type='textarea'
             className='resize-x w-full  h-4'
           >

--- a/components/MintBounty/TierInput.js
+++ b/components/MintBounty/TierInput.js
@@ -1,30 +1,105 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, useRef, useMemo } from 'react';
 import StoreContext from '../../store/Store/StoreContext';
 
-const TierInput = ({ tier, tierVolume, onTierVolumeChange, style }) => {
+const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
   // State
   const [suffix, setSuffix] = useState();
   const [appState] = useContext(StoreContext);
+  const createReactScale = (tierVolumes, tier) => {
+    return (tierVolumes[tier] || 1) / 100;
+  };
+  const memoizedScale = useMemo(() => createReactScale(tierVolumes, tier), [tierVolumes, tier]);
+  const [reactScale, setReactScale] = useState(memoizedScale);
+  const widthParent = useRef();
+  const edgeOfScale = useRef();
+  const tierIndex = parseInt(tier);
 
+  const saturation = tierIndex % 2 ? 84 - tierIndex : 84 - tierIndex + 1;
+  const lightness = !(tierIndex % 2) ? 48 + tierIndex : 48 + tierIndex - 1;
+  const hue = 400 - tierIndex * 67;
   useEffect(() => {
-    setSuffix(appState.utils.handleSuffix(tier));
-  }, []);
+    handleChange(reactScale, tierVolumes);
+  }, [reactScale]);
+  useEffect(() => {
+    if (edgeOfScale.current) {
+      setSuffix(appState.utils.handleSuffix(tier));
+      let drag = false;
+      let ogWidth = 0;
+      let scale = 0;
+      const handleMouseMove = (e) => {
+        if (drag) {
+          const start = widthParent.current.getBoundingClientRect().x;
+          const newPxWidth = e.clientX - start;
+          const newScale = newPxWidth / ogWidth;
+          scale = newScale;
+          if (newScale > 0 && newScale < 1) {
+            setReactScale(scale);
+          } else if (newScale > 1) {
+            setReactScale(1);
+          } else if (newScale < 0) {
+            setReactScale(0);
+          }
+        }
+      };
+      const handleDragEnd = () => {
+        drag = false;
+      };
+      const handleDragBegin = () => {
+        if (ogWidth === 0) {
+          ogWidth = widthParent.current.clientWidth;
+        }
+        drag = true;
+      };
+      window.addEventListener('mouseup', handleDragEnd);
+      window.addEventListener('mousemove', handleMouseMove);
+      edgeOfScale.current.addEventListener('mousedown', handleDragBegin);
 
-  const label = `tier ${tier}`;
+      () => {
+        window.removeEventListener('mouseup');
+        edgeOfScale.current.removeEventListener('mousemove');
+        edgeOfScale.current.removeEventListener('mousedown');
+      };
+    }
+  }, [widthParent.current, edgeOfScale.current]);
+  const handleChange = (percentage, tierVolumes) => {
+    onTierVolumeChange(
+      {
+        name: tier,
+
+        target: {
+          value: parseInt(percentage * 100),
+        },
+      },
+      tierVolumes
+    );
+  };
 
   return (
-    <div className={`flex-1 w-11/12 mb-1  ml-4 ${style}`}>
-      <input
-        name={tier}
-        aria-label={label}
-        id='tier-volume'
-        autoComplete='off'
-        placeholder={`${suffix} winner`}
-        value={tierVolume || ''}
-        onChange={onTierVolumeChange}
-        className='input-field w-full number'
-      />
-    </div>
+    <>
+      <div>{suffix} place winner</div>
+      <div className={`flex w-11/12 text-sm content-center items-center gap-2 mb-1 ${style}`}>
+        <div className='w-9 flex none'>{tierVolumes[tier]}%</div>
+        <div ref={widthParent} className='w-full rounded-full overflow-hidden border border-transparent h-4'>
+          <div
+            style={{
+              transform: `scaleX(${reactScale})`,
+              transformOrigin: 'left center',
+              backgroundColor: `hsl(${hue}, ${saturation}%, ${lightness}%)`,
+            }}
+            data-testId={'tierInput'}
+            type='textarea'
+            className='resize-x w-full  h-4'
+          >
+            <div
+              ref={edgeOfScale}
+              style={{ transform: `scaleX(${1 / reactScale})` }}
+              type='textarea'
+              className='resize-x w-6 opacity-0  h-4 float-right relative left-3 cursor-ew-resize overflow-visible'
+            ></div>
+          </div>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/components/MintBounty/TierInput.js
+++ b/components/MintBounty/TierInput.js
@@ -13,7 +13,6 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
   const widthParent = useRef();
   const edgeOfScale = useRef();
   const tierIndex = parseInt(tier);
-
   const saturation = tierIndex % 2 ? 84 - tierIndex : 84 - tierIndex + 1;
   const lightness = !(tierIndex % 2) ? 48 + tierIndex : 48 + tierIndex - 1;
   const hue = 400 - tierIndex * 67;
@@ -22,7 +21,7 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
   }, [reactScale]);
   useEffect(() => {
     if (edgeOfScale.current) {
-      setSuffix(appState.utils.handleSuffix(tier));
+      setSuffix(appState.utils.handleSuffix(parseInt(tier) + 1));
       let drag = false;
       let ogWidth = 0;
       let scale = 0;
@@ -36,8 +35,8 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
             setReactScale(scale);
           } else if (newScale > 1) {
             setReactScale(1);
-          } else if (newScale < 0) {
-            setReactScale(0);
+          } else if (newScale <= 1) {
+            setReactScale(0.01);
           }
         }
       };
@@ -78,7 +77,7 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
     <>
       <div>{suffix} place winner</div>
       <div className={`flex w-11/12 text-sm content-center items-center gap-2 mb-1 ${style}`}>
-        <div className='w-9 flex none'>{tierVolumes[tier]}%</div>
+        <div className='w-9 flex none w-full'>{tierVolumes[tier]}%</div>
         <div ref={widthParent} className='w-full rounded-full overflow-hidden border border-transparent h-4'>
           <div
             style={{

--- a/components/MintBounty/TierResult.js
+++ b/components/MintBounty/TierResult.js
@@ -1,0 +1,39 @@
+import React, { useRef } from 'react';
+
+const TierResult = ({ finalTierVolumes, sum }) => {
+  const container = useRef();
+  return (
+    <>
+      Total
+      <div className={`flex w-11/12 text-sm  w-full items-center gap-2 mb-1`}>
+        <div className='w-9 flex-none'>{sum}%</div>
+        <div
+          ref={container}
+          className={`flex border-transparent border-2 flex-none rounded-full overflow-hidden w-full relative ${
+            sum < 100 ? 'border-gray-500' : sum > 100 ? 'border-red-500' : 'border-primary'
+          }`}
+        >
+          {finalTierVolumes.map((volume, index) => {
+            const saturation = index % 2 ? 84 - index : 84 - index + 1;
+            const lightness = !(index % 2) ? 48 + index : 48 + index - 1;
+            const hue = 400 - (index + 1) * 67;
+            return (
+              <div
+                key={index}
+                style={{
+                  width: `${
+                    (container.current && container.current.clientWidth * finalTierVolumes[index] + 50) / 100
+                  }px`,
+                  backgroundColor: `hsl(${hue}, ${saturation}%, ${lightness}%)`,
+                }}
+                type='textarea'
+                className='resize-x h-4 w-full inline z-15 left-0 top-0'
+              ></div>
+            );
+          })}
+        </div>
+      </div>{' '}
+    </>
+  );
+};
+export default TierResult;

--- a/components/MintBounty/TierResult.js
+++ b/components/MintBounty/TierResult.js
@@ -16,7 +16,7 @@ const TierResult = ({ finalTierVolumes, sum }) => {
           {finalTierVolumes.map((volume, index) => {
             const saturation = index % 2 ? 84 - index : 84 - index + 1;
             const lightness = !(index % 2) ? 48 + index : 48 + index - 1;
-            const hue = 400 - (index + 1) * 67;
+            const hue = 400 - index * 67;
             return (
               <div
                 key={index}

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -7,6 +7,7 @@ import ToolTipNew from '../Utils/ToolTipNew';
 const DepositCard = ({
   deposit,
   refundBounty,
+  closed,
   extendBounty,
   status,
   isOnCorrectNetwork,
@@ -64,7 +65,7 @@ const DepositCard = ({
               </button>
             </ToolTipNew>
           )}
-          {status !== 'refunded' && (
+          {status !== 'refunded' && !closed && (
             <>
               {expanded ? (
                 <div className=' text-primary flex flex-col md:flex-row md:space-x-2 items-center'>

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -47,8 +47,8 @@ const DepositCard = ({
             </div>
           )}
         </div>
-        
-          <div className='flex flex-col space-y-3 w-44 pl-3 text-primary'>
+
+        <div className='flex flex-col space-y-3 w-44 pl-3 text-primary'>
           {status === 'refundable' && (
             <ToolTipNew
               outerStyles='flex'
@@ -64,75 +64,76 @@ const DepositCard = ({
               </button>
             </ToolTipNew>
           )}
-          {status !== 'refunded' && <>
-            {expanded ? (
-              <div className=' text-primary flex flex-col md:flex-row md:space-x-2 items-center'>
-                <div className='flex w-full input-field-big pl-4 justify-between'>
-                  <div className=' flex items-center'>
-                    <ToolTipNew
-                      innerStyles={'whitespace-normal w-80'}
-                      toolTipText={
-                        "This is the number of days that your deposit will be in escrow. After this many days, you're deposit will be fully refundable if the bounty has still not been claimed."
-                      }
-                    >
-                      <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
-                        ?
-                      </div>
-                    </ToolTipNew>
-                  </div>
+          {status !== 'refunded' && (
+            <>
+              {expanded ? (
+                <div className=' text-primary flex flex-col md:flex-row md:space-x-2 items-center'>
+                  <div className='flex w-full input-field-big pl-4 justify-between'>
+                    <div className=' flex items-center'>
+                      <ToolTipNew
+                        innerStyles={'whitespace-normal w-80'}
+                        toolTipText={
+                          "This is the number of days that your deposit will be in escrow. After this many days, you're deposit will be fully refundable if the bounty has still not been claimed."
+                        }
+                      >
+                        <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
+                          ?
+                        </div>
+                      </ToolTipNew>
+                    </div>
 
-                  <input
-                    className='flex w-full md:w-12 text-primary text-right number outline-none bg-dark-mode'
-                    autoComplete='off'
-                    value={depositPeriodDays || 0}
-                    name={deposit.id}
-                    id='deposit-period'
-                    onChange={onDepositPeriodChanged}
-                    placeholder='0'
-                  />
+                    <input
+                      className='flex w-full md:w-12 text-primary text-right number outline-none bg-dark-mode'
+                      autoComplete='off'
+                      value={depositPeriodDays || 0}
+                      name={deposit.id}
+                      id='deposit-period'
+                      onChange={onDepositPeriodChanged}
+                      placeholder='0'
+                    />
+                  </div>
+                  <ToolTipNew
+                    outerStyles='flex w-full items-center'
+                    hideToolTip={isOnCorrectNetwork && depositPeriodDays > 0}
+                    toolTipText={
+                      !isOnCorrectNetwork
+                        ? 'Please switch to the correct network to extend this bounty.'
+                        : !(depositPeriodDays > 0)
+                        ? "Please indicate how many days you'd like to extend your bounty for."
+                        : null
+                    }
+                  >
+                    <button
+                      onClick={() => extendBounty(deposit.id)}
+                      disabled={!isOnCorrectNetwork || !(depositPeriodDays > 0)}
+                      className={`flex mt-3 md:mt-0 text-center w-full px-3 justify-center ${
+                        isOnCorrectNetwork && depositPeriodDays > 0
+                          ? 'btn-primary cursor-pointer p-1'
+                          : 'btn-default cursor-not-allowed'
+                      }`}
+                    >
+                      Extend
+                    </button>
+                  </ToolTipNew>
                 </div>
+              ) : (
                 <ToolTipNew
-                  outerStyles='flex w-full items-center'
-                  hideToolTip={isOnCorrectNetwork && depositPeriodDays > 0}
-                  toolTipText={
-                    !isOnCorrectNetwork
-                      ? 'Please switch to the correct network to extend this bounty.'
-                      : !(depositPeriodDays > 0)
-                      ? "Please indicate how many days you'd like to extend your bounty for."
-                      : null
-                  }
+                  outerStyles='flex self-center'
+                  hideToolTip={isOnCorrectNetwork}
+                  toolTipText={'Please switch to the correct network to refund this deposit.'}
                 >
                   <button
-                    onClick={() => extendBounty(deposit.id)}
-                    disabled={!isOnCorrectNetwork || !(depositPeriodDays > 0)}
-                    className={`flex mt-3 md:mt-0 text-center w-full px-3 justify-center ${
-                      isOnCorrectNetwork && depositPeriodDays > 0
-                        ? 'btn-primary cursor-pointer p-1'
-                        : 'btn-default cursor-not-allowed'
-                    }`}
+                    onClick={() => setExpanded(!expanded)}
+                    disabled={!isOnCorrectNetwork}
+                    className={`${isOnCorrectNetwork ? 'btn-default w-full' : 'btn-default cursor-not-allowed w-full'}`}
                   >
                     Extend
                   </button>
                 </ToolTipNew>
-              </div>
-            ) : (
-              <ToolTipNew
-                outerStyles='flex self-center'
-                hideToolTip={isOnCorrectNetwork}
-                toolTipText={'Please switch to the correct network to refund this deposit.'}
-              >
-                <button
-                  onClick={() => setExpanded(!expanded)}
-                  disabled={!isOnCorrectNetwork}
-                  className={`${isOnCorrectNetwork ? 'btn-default w-full' : 'btn-default cursor-not-allowed w-full'}`}
-                >
-                  Extend
-                </button>
-              </ToolTipNew>
-            )} </>
-            }
-          </div>
-        
+              )}{' '}
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/components/RefundBounty/RefundPage.js
+++ b/components/RefundBounty/RefundPage.js
@@ -115,7 +115,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
         <>{internalMenu === 'Refund' && <BountyClosed bounty={bounty} />}</>
       ) : (
         <div
-          className={`flex flex-1 px-12 pt-4 pb-8 w-full max-w-[1200px] justify-center ${
+          className={`flex flex-1 pt-4 pb-8 w-full max-w-[1200px] justify-center ${
             internalMenu !== 'Refund' ? 'hidden' : null
           }`}
         >
@@ -195,25 +195,25 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                       return (
                         <div key={deposit.id}>
                           <DepositCard
-                          deposit={deposit}
-                          status='not-yet-refundable'
-                          bounty={bounty}
-                          onDepositPeriodChanged={onDepositPeriodChanged}
-                          depositPeriodDays={depositPeriodDays[deposit.id]}
-                          extendBounty={() => {
-                            setConfirmationMessage(
-                              `You are about to extend the bounty at ${bounty.bountyAddress.substring(
-                                0,
-                                12
-                              )}...${bounty.bountyAddress.substring(32)} by ${depositPeriodDays[deposit.id]} ${
-                                depositPeriodDays[deposit.id] == 1 ? 'day' : 'days'
-                              }.	Are you sure you want to extend this deposit?`
-                            );
-                            setExtend(true);
-                            setApproveTransferState(CONFIRM);
-                            setShowApproveTransferModal(deposit.id);
-                          }}
-                          isOnCorrectNetwork={isOnCorrectNetwork}
+                            deposit={deposit}
+                            status='not-yet-refundable'
+                            bounty={bounty}
+                            onDepositPeriodChanged={onDepositPeriodChanged}
+                            depositPeriodDays={depositPeriodDays[deposit.id]}
+                            extendBounty={() => {
+                              setConfirmationMessage(
+                                `You are about to extend the bounty at ${bounty.bountyAddress.substring(
+                                  0,
+                                  12
+                                )}...${bounty.bountyAddress.substring(32)} by ${depositPeriodDays[deposit.id]} ${
+                                  depositPeriodDays[deposit.id] == 1 ? 'day' : 'days'
+                                }.	Are you sure you want to extend this deposit?`
+                              );
+                              setExtend(true);
+                              setApproveTransferState(CONFIRM);
+                              setShowApproveTransferModal(deposit.id);
+                            }}
+                            isOnCorrectNetwork={isOnCorrectNetwork}
                           />
                         </div>
                       );

--- a/components/RefundBounty/RefundPage.js
+++ b/components/RefundBounty/RefundPage.js
@@ -6,6 +6,7 @@ import { ethers } from 'ethers';
 // Custom
 import StoreContext from '../../store/Store/StoreContext';
 import DepositCard from './DepositCard';
+import ToolTipNew from '../Utils/ToolTipNew';
 import BountyClosed from '../BountyClosed/BountyClosed';
 import useEns from '../../hooks/useENS';
 import ApproveTransferModal from './ApproveTransferModal';
@@ -111,7 +112,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
 
   return (
     <>
-      {closed ? (
+      {closed && bounty.bountyType === '0' ? (
         <>{internalMenu === 'Refund' && <BountyClosed bounty={bounty} />}</>
       ) : (
         <div
@@ -125,7 +126,22 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
             </h1>
             <div className='flex flex-col space-y-5 w-full px-8 pt-2'>
               <div className=' text-center'>To see your deposits, connect the wallet that funded them.</div>
-              <h2 className='text-2xl border-b border-gray-700 pb-4'>Refundable</h2>
+              <h2 className='text-2xl border-b border-gray-700 pb-4 flex contents-center items-center gap-4'>
+                <span>{closed && 'Partially'} Refundable</span>
+                <span>
+                  <ToolTipNew
+                    innerStyles={'w-48 whitespace-normal'}
+                    mobileX={10}
+                    toolTipText={
+                      'This bounty is already closed, if claims have been made on this competition, you may not be able to refund your deposit.'
+                    }
+                  >
+                    <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square text-sm leading-4 h-4 box-content text-center font-bold text-primary'>
+                      ?
+                    </div>
+                  </ToolTipNew>
+                </span>
+              </h2>
               <div className='lg:grid lg:grid-cols-[1fr_1fr] gap-4 pb-5'>
                 {bounty.deposits &&
                   bounty.deposits
@@ -137,7 +153,8 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                     })
                     .filter((deposit) => {
                       return (
-                        parseInt(deposit.receiveTime) + parseInt(deposit.expiration) < Math.floor(Date.now() / 1000)
+                        parseInt(deposit.receiveTime) + 10000000 + parseInt(deposit.expiration) <
+                        Math.floor(Date.now() / 1000)
                       );
                     })
                     .map((deposit) => {
@@ -146,6 +163,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                           <DepositCard
                             deposit={deposit}
                             status='refundable'
+                            closed={closed}
                             bounty={bounty}
                             onDepositPeriodChanged={onDepositPeriodChanged}
                             depositPeriodDays={depositPeriodDays[deposit.id]}
@@ -188,7 +206,8 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                     })
                     .filter((deposit) => {
                       return (
-                        parseInt(deposit.receiveTime) + parseInt(deposit.expiration) > Math.floor(Date.now() / 1000)
+                        parseInt(deposit.receiveTime) + 1000000000 + parseInt(deposit.expiration) >
+                        Math.floor(Date.now() / 1000)
                       );
                     })
                     .map((deposit) => {
@@ -196,6 +215,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                         <div key={deposit.id}>
                           <DepositCard
                             deposit={deposit}
+                            closed={closed}
                             status='not-yet-refundable'
                             bounty={bounty}
                             onDepositPeriodChanged={onDepositPeriodChanged}

--- a/components/RefundBounty/RefundPage.js
+++ b/components/RefundBounty/RefundPage.js
@@ -153,8 +153,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                     })
                     .filter((deposit) => {
                       return (
-                        parseInt(deposit.receiveTime) + 10000000 + parseInt(deposit.expiration) <
-                        Math.floor(Date.now() / 1000)
+                        parseInt(deposit.receiveTime) + parseInt(deposit.expiration) < Math.floor(Date.now() / 1000)
                       );
                     })
                     .map((deposit) => {
@@ -206,8 +205,7 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                     })
                     .filter((deposit) => {
                       return (
-                        parseInt(deposit.receiveTime) + 1000000000 + parseInt(deposit.expiration) >
-                        Math.floor(Date.now() / 1000)
+                        parseInt(deposit.receiveTime) + parseInt(deposit.expiration) > Math.floor(Date.now() / 1000)
                       );
                     })
                     .map((deposit) => {

--- a/components/Stream/ApproveStreamModal.js
+++ b/components/Stream/ApproveStreamModal.js
@@ -259,13 +259,13 @@ const ApproveStreamModal = ({
                         }
                       >
                         {' '}
-                        <span className='flex self-center content-center'>
+                        <div className='flex h-full self-center content-center'>
                           {approveTransferState === CONFIRM
                             ? 'Approve'
                             : approveTransferState === APPROVING
                             ? 'Approving'
                             : 'Approved'}
-                        </span>
+                        </div>
                       </ToolTipNew>
                       {approveTransferState === APPROVING && <LoadingIcon className={'self-center mt-0.5'} />}
                     </button>

--- a/components/Utils/ActionBubble.js
+++ b/components/Utils/ActionBubble.js
@@ -54,10 +54,18 @@ const ActionBubble = ({ addresses, bounty, action }) => {
   if (action?.claimTime) {
     const claimant = claimantEnsName || shortenAddress(action.claimant.id);
     address = action.claimant.id;
+    const [tokenValues] = useGetTokenValues(
+      bounty?.payouts?.filter((payout) => payout.closer.id == address && payout.payoutTime == action.claimTime)
+    );
+    const TVL = appState.utils.formatter.format(tokenValues?.total);
     if (bounty.bountyType === '0') {
-      titlePartOne = `${claimant} claimed this contract on ${appState.utils.formatUnixDate(action.claimTime)}.`;
+      titlePartOne = `${claimant} claimed ${TVL} on this contract on ${appState.utils.formatUnixDate(
+        action.claimTime
+      )}.`;
     } else {
-      titlePartOne = `${claimant} made a claim on this contract on ${appState.utils.formatUnixDate(action.claimTime)}.`;
+      titlePartOne = `${claimant} made a claim of ${TVL} on this contract on ${appState.utils.formatUnixDate(
+        action.claimTime
+      )}.`;
     }
   }
   if (action?.referencedTime) {

--- a/components/Utils/ActionBubble.js
+++ b/components/Utils/ActionBubble.js
@@ -52,12 +52,26 @@ const ActionBubble = ({ addresses, bounty, action }) => {
   }
 
   if (action?.claimTime) {
+    console.log(
+      'action: ',
+      bounty,
+      bounty?.payouts?.filter((payout) => payout.closer.id == address && payout.payoutTime == action.claimTime)
+    );
+
     const claimant = claimantEnsName || shortenAddress(action.claimant.id);
     address = action.claimant.id;
+    const [tokenValues] = useGetTokenValues(
+      bounty?.payouts?.filter((payout) => payout.closer.id == address && payout.payoutTime == action.claimTime)
+    );
+    const TVL = appState.utils.formatter.format(tokenValues?.total);
     if (bounty.bountyType === '0') {
-      titlePartOne = `${claimant} claimed this contract on ${appState.utils.formatUnixDate(action.claimTime)}.`;
+      titlePartOne = `${claimant} claimed ${TVL} on this contract on ${appState.utils.formatUnixDate(
+        action.claimTime
+      )}.`;
     } else {
-      titlePartOne = `${claimant} made a claim on this contract on ${appState.utils.formatUnixDate(action.claimTime)}.`;
+      titlePartOne = `${claimant} made a claim of ${TVL} on this contract on ${appState.utils.formatUnixDate(
+        action.claimTime
+      )}.`;
     }
   }
   if (action?.referencedTime) {

--- a/components/Utils/SmallToggle.js
+++ b/components/Utils/SmallToggle.js
@@ -1,9 +1,9 @@
 // Thrid Party
 import React from 'react';
 
-const SmallToggle = ({ toggleFunc, toggleVal, names }) => {
+const SmallToggle = ({ toggleFunc, toggleVal, names, className }) => {
   return (
-    <div className='flex text-sm rounded-sm overflow-hidden w-fit text-primary '>
+    <div className={`flex text-sm rounded-sm overflow-hidden w-fit ${className} text-primary `}>
       {names.map((name, index) => {
         return (
           <button

--- a/components/Utils/ToolTipNew.js
+++ b/components/Utils/ToolTipNew.js
@@ -1,9 +1,17 @@
 import React from 'react';
 
-const ToolTipNew = ({ toolTipText, children, hideToolTip, outerStyles, innerStyles, relativePosition }) => {
+const ToolTipNew = ({
+  toolTipText,
+  children,
+  groupStyles,
+  hideToolTip,
+  outerStyles,
+  innerStyles,
+  relativePosition,
+}) => {
   if (hideToolTip) return children;
   return (
-    <div className={'group'}>
+    <div className={`group ${groupStyles}`}>
       {children}
       <div className={`justify-center w-full relative hidden z-50 group-hover:block  ${outerStyles} `}>
         <div className='flex flex-col items-center'>

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '^@components(.*)$': '<rootDir>/components$1',
     '^@pages(.*)$': '<rootDir>/pages$1',
     '^@hooks(.*)$': '<rootDir>/hooks$1',
+    '^d3$': '<rootDir>/node_modules/d3/dist/d3.min.js',
   },
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"canvas-confetti": "^1.5.1",
 		"chai": "^4.3.4",
 		"cross-fetch": "^3.1.4",
+		"d3": "^7.6.1",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-unused-imports": "^1.1.5",

--- a/pages/[type].js
+++ b/pages/[type].js
@@ -140,9 +140,8 @@ export const getServerSideProps = async (ctx) => {
       types = ['2', '3'];
       category = 'contest';
       break;
-    case 'learn2earn':
+    case 'split-price':
       category = 'learn2earn';
-
       types = ['1'];
       break;
   }

--- a/pages/bounty/[id]/[address].js
+++ b/pages/bounty/[id]/[address].js
@@ -21,6 +21,7 @@ import useAuth from '../../../hooks/useAuth';
 import RepoTitle from '../../../components/Bounty/RepoTitle';
 import SubMenu from '../../../components/Utils/SubMenu';
 import BountyHeading from '../../../components/Bounty/BountyHeading';
+import BountyMetadata from '../../../components/Bounty/BountyMetadata';
 
 import Add from '../../../components/svg/add';
 import Subtract from '../../../components/svg/subtract';
@@ -208,30 +209,49 @@ const address = ({ address, mergedBounty, renderError }) => {
               />
 
               <BountyHeading tokenValues={tokenValues} budgetValues={budgetValues} bounty={bounty} />
-              {internalMenu == 'View' && (
-                <BountyCardDetails
-                  justMinted={justMinted}
-                  budgetValues={budgetValues}
-                  split={split}
-                  bounty={bounty}
-                  setInternalMenu={setInternalMenu}
-                  address={address}
-                  tokenValues={tokenValues}
-                  internalMenu={internalMenu}
-                />
-              )}
-              {internalMenu == 'Fund' && bounty ? <FundPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
-              {internalMenu == 'Claim' && bounty ? <ClaimPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
-              {internalMenu == 'Admin' && bounty && ethers.utils.getAddress(bounty.issuer.id) == account ? (
-                <AdminPage
-                  bounty={bounty}
-                  refreshBounty={refreshBounty}
+
+              <div className='flex justify-between  w-full px-2 sm:px-8 flex-wrap max-w-[1200px] pb-8 mx-auto'>
+                {internalMenu == 'View' && (
+                  <BountyCardDetails
+                    justMinted={justMinted}
+                    budgetValues={budgetValues}
+                    split={split}
+                    bounty={bounty}
+                    setInternalMenu={setInternalMenu}
+                    address={address}
+                    tokenValues={tokenValues}
+                    internalMenu={internalMenu}
+                  />
+                )}
+                {internalMenu == 'Fund' && bounty ? (
+                  <FundPage
+                    bounty={bounty}
+                    refreshBounty={refreshBounty}
+                    price={tokenValues?.total}
+                    budget={budget}
+                    split={split}
+                  />
+                ) : null}
+                {internalMenu == 'Claim' && bounty ? <ClaimPage bounty={bounty} refreshBounty={refreshBounty} /> : null}
+                {internalMenu == 'Admin' && bounty && ethers.utils.getAddress(bounty.issuer.id) == account ? (
+                  <AdminPage
+                    bounty={bounty}
+                    refreshBounty={refreshBounty}
+                    price={tokenValues?.total}
+                    budget={budget}
+                    split={split}
+                  />
+                ) : null}
+                {bounty && <RefundPage bounty={bounty} refreshBounty={refreshBounty} internalMenu={internalMenu} />}
+
+                <BountyMetadata
                   price={tokenValues?.total}
                   budget={budget}
                   split={split}
+                  bounty={bounty}
+                  setInternalMenu={setInternalMenu}
                 />
-              ) : null}
-              {bounty && <RefundPage bounty={bounty} refreshBounty={refreshBounty} internalMenu={internalMenu} />}
+              </div>
               <canvas className='absolute w-full top-0 z-40 bottom-0 pointer-events-none' ref={canvas}></canvas>
             </div>
           </>

--- a/services/ethers/OpenQClient.js
+++ b/services/ethers/OpenQClient.js
@@ -62,7 +62,7 @@ class OpenQClient {
       );
       const hasFundingGoal = fundVolumeInWei > 0;
       switch (type) {
-        case 'Atomic':
+        case 'Fixed Price':
           {
             const fundingGoalBountyParams = abiCoder.encode(
               ['bool', 'address', 'uint256'],
@@ -71,7 +71,7 @@ class OpenQClient {
             bountyInitOperation = [0, fundingGoalBountyParams];
           }
           break;
-        case 'Repeating':
+        case 'Split Price':
           {
             const payoutVolumeInWei = data.payoutVolume * 10 ** data.payoutToken.decimals;
             const payoutBigNumberVolumeInWei = ethers.BigNumber.from(
@@ -99,6 +99,15 @@ class OpenQClient {
               [data.tiers, hasFundingGoal, data.fundingTokenAddress.address, fundBigNumberVolumeInWei]
             );
             bountyInitOperation = [2, tieredAbiEncodedParams];
+          }
+          break;
+        case 'Fixed Contest':
+          {
+            const tieredAbiEncodedParams = abiCoder.encode(
+              ['uint256[]', 'address'],
+              [data.tiers, data.payoutToken.address]
+            );
+            bountyInitOperation = [3, tieredAbiEncodedParams];
           }
           break;
         default:

--- a/services/subgraph/graphql/query.js
+++ b/services/subgraph/graphql/query.js
@@ -29,6 +29,10 @@ export const GET_ALL_BOUNTIES = gql`
       payouts {
         tokenAddress
         volume
+        payoutTime
+        closer {
+          id
+        }
       }
       deposits {
         id
@@ -100,6 +104,10 @@ export const GET_BOUNTY = gql`
       payouts {
         tokenAddress
         volume
+        payoutTime
+        closer {
+          id
+        }
       }
       claimedTransactionHash
       payoutAddress
@@ -205,6 +213,10 @@ export const GET_BOUNTIES_BY_CONTRACT_ADDRESSES = gql`
       payouts {
         tokenAddress
         volume
+        payoutTime
+        closer {
+          id
+        }
       }
       issuer {
         id

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -104,7 +104,7 @@ pre {
 		@apply bg-[#238636] border border-[#238636] rounded-sm py-1.5 hover:bg-[#2ea043] text-white
 	}
 	.btn-default{
-		@apply rounded-sm px-3 p-1 bg-[#21262d] hover:bg-[#30363d] border border-gray-700 hover:border-[#8b949e]
+		@apply rounded-sm px-3 py-1 bg-[#21262d] hover:bg-[#30363d] border border-gray-700 hover:border-[#8b949e]
 	}
 	.btn-danger{
 		@apply text-[#f85149] hover:text-white rounded-sm px-3 p-1 bg-[#21262d] hover:bg-[#da3633] active:bg-[#b62324] border border-[rgba(240,246,252,0.1)] hover:border-[#f85149] active:border-[#ff7b72]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2278,14 +2278,6 @@ agent-base@6:
   dependencies:
     debug "4"
 
-aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
-
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
@@ -2365,11 +2357,6 @@ ansi-regex@^5.0.1:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
-  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
-
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
@@ -2388,11 +2375,6 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
-
-ansi-styles@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.1.0.tgz#87313c102b8118abd57371afab34618bf7350ed3"
-  integrity sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==
 
 antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"
@@ -2938,7 +2920,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3448,38 +3430,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
 cli-boxes@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
-
-cli-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
-  dependencies:
-    restore-cursor "^3.1.0"
-
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
-  dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
-
-cli-truncate@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
-  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
-  dependencies:
-    slice-ansi "^5.0.0"
-    string-width "^5.0.0"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -3598,11 +3552,6 @@ color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
-colorette@^2.0.16, colorette@^2.0.17:
-  version "2.0.19"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
-  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
-
 combine-source-map@^0.8.0, combine-source-map@~0.8.0:
   version "0.8.0"
   resolved "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz"
@@ -3630,15 +3579,10 @@ commander@3.0.2:
   resolved "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz"
   integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
-commander@^9.3.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
-  integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
-
-compare-versions@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
-  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+commander@7:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -3781,7 +3725,7 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
+cosmiconfig@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
@@ -3938,6 +3882,250 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", "d3-array@2.5.0 - 3", d3-array@3, d3-array@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.0.tgz#15bf96cd9b7333e02eb8de8053d78962eafcff14"
+  integrity sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==
+  dependencies:
+    internmap "1 - 2"
+
+d3-axis@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-3.0.0.tgz#c42a4a13e8131d637b745fc2973824cfeaf93322"
+  integrity sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+
+d3-brush@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-3.0.0.tgz#6f767c4ed8dcb79de7ede3e1c0f89e63ef64d31c"
+  integrity sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "3"
+    d3-transition "3"
+
+d3-chord@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-3.0.1.tgz#d156d61f485fce8327e6abf339cb41d8cbba6966"
+  integrity sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-color@1 - 3", d3-color@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-contour@4:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-4.0.0.tgz#5a1337c6da0d528479acdb5db54bc81a0ff2ec6b"
+  integrity sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==
+  dependencies:
+    d3-array "^3.2.0"
+
+d3-delaunay@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-6.0.2.tgz#7fd3717ad0eade2fc9939f4260acfb503f984e92"
+  integrity sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==
+  dependencies:
+    delaunator "5"
+
+"d3-dispatch@1 - 3", d3-dispatch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz#5fc75284e9c2375c36c839411a0cf550cbfc4d5e"
+  integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+
+"d3-drag@2 - 3", d3-drag@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-3.0.0.tgz#994aae9cd23c719f53b5e10e3a0a6108c69607ba"
+  integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-selection "3"
+
+"d3-dsv@1 - 3", d3-dsv@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-3.0.1.tgz#c63af978f4d6a0d084a52a673922be2160789b73"
+  integrity sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+  dependencies:
+    commander "7"
+    iconv-lite "0.6"
+    rw "1"
+
+"d3-ease@1 - 3", d3-ease@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+d3-fetch@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-3.0.1.tgz#83141bff9856a0edb5e38de89cdcfe63d0a60a22"
+  integrity sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+  dependencies:
+    d3-dsv "1 - 3"
+
+d3-force@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-3.0.0.tgz#3e2ba1a61e70888fe3d9194e30d6d14eece155c4"
+  integrity sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-quadtree "1 - 3"
+    d3-timer "1 - 3"
+
+"d3-format@1 - 3", d3-format@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
+
+d3-geo@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.0.1.tgz#4f92362fd8685d93e3b1fae0fd97dc8980b1ed7e"
+  integrity sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==
+  dependencies:
+    d3-array "2.5.0 - 3"
+
+d3-hierarchy@3:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz#b01cd42c1eed3d46db77a5966cf726f8c09160c6"
+  integrity sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+
+"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+"d3-path@1 - 3", d3-path@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.0.1.tgz#f09dec0aaffd770b7995f1a399152bf93052321e"
+  integrity sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==
+
+d3-polygon@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-3.0.1.tgz#0b45d3dd1c48a29c8e057e6135693ec80bf16398"
+  integrity sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+
+"d3-quadtree@1 - 3", d3-quadtree@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-3.0.1.tgz#6dca3e8be2b393c9a9d514dabbd80a92deef1a4f"
+  integrity sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+
+d3-random@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-3.0.1.tgz#d4926378d333d9c0bfd1e6fa0194d30aebaa20f4"
+  integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+
+d3-scale-chromatic@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
+
+d3-scale@4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+"d3-selection@2 - 3", d3-selection@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+
+d3-shape@3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.1.0.tgz#c8a495652d83ea6f524e482fca57aa3f8bc32556"
+  integrity sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==
+  dependencies:
+    d3-path "1 - 3"
+
+"d3-time-format@2 - 4", d3-time-format@4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.0.0.tgz#65972cb98ae2d4954ef5c932e8704061335d4975"
+  integrity sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==
+  dependencies:
+    d3-array "2 - 3"
+
+"d3-timer@1 - 3", d3-timer@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+
+"d3-transition@2 - 3", d3-transition@3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-3.0.1.tgz#6869fdde1448868077fdd5989200cb61b2a1645f"
+  integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+  dependencies:
+    d3-color "1 - 3"
+    d3-dispatch "1 - 3"
+    d3-ease "1 - 3"
+    d3-interpolate "1 - 3"
+    d3-timer "1 - 3"
+
+d3-zoom@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-3.0.0.tgz#d13f4165c73217ffeaa54295cd6969b3e7aee8f3"
+  integrity sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+  dependencies:
+    d3-dispatch "1 - 3"
+    d3-drag "2 - 3"
+    d3-interpolate "1 - 3"
+    d3-selection "2 - 3"
+    d3-transition "2 - 3"
+
+d3@^7.6.1:
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-7.6.1.tgz#b21af9563485ed472802f8c611cc43be6c37c40c"
+  integrity sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==
+  dependencies:
+    d3-array "3"
+    d3-axis "3"
+    d3-brush "3"
+    d3-chord "3"
+    d3-color "3"
+    d3-contour "4"
+    d3-delaunay "6"
+    d3-dispatch "3"
+    d3-drag "3"
+    d3-dsv "3"
+    d3-ease "3"
+    d3-fetch "3"
+    d3-force "3"
+    d3-format "3"
+    d3-geo "3"
+    d3-hierarchy "3"
+    d3-interpolate "3"
+    d3-path "3"
+    d3-polygon "3"
+    d3-quadtree "3"
+    d3-random "3"
+    d3-scale "4"
+    d3-scale-chromatic "3"
+    d3-selection "3"
+    d3-shape "3"
+    d3-time "3"
+    d3-time-format "4"
+    d3-timer "3"
+    d3-transition "3"
+    d3-zoom "3"
+
 damerau-levenshtein@^1.0.7:
   version "1.0.8"
   resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
@@ -3991,13 +4179,6 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -4113,6 +4294,13 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
+
+delaunator@5:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.0.tgz#60f052b28bd91c9b4566850ebf7756efe821d81b"
+  integrity sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==
+  dependencies:
+    robust-predicates "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -4281,11 +4469,6 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
-
-eastasianwidth@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
-  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -4906,21 +5089,6 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-execa@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-6.1.0.tgz#cea16dee211ff011246556388effa0818394fb20"
-  integrity sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==
-  dependencies:
-    cross-spawn "^7.0.3"
-    get-stream "^6.0.1"
-    human-signals "^3.0.1"
-    is-stream "^3.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^5.1.0"
-    onetime "^6.0.0"
-    signal-exit "^3.0.7"
-    strip-final-newline "^3.0.0"
-
 exit-on-epipe@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz"
@@ -5151,21 +5319,6 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
-  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
-  dependencies:
-    locate-path "^6.0.0"
-    path-exists "^4.0.0"
-
-find-versions@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-4.0.0.tgz#3c57e573bf97769b8cb8df16934b627915da4965"
-  integrity sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==
-  dependencies:
-    semver-regex "^3.1.2"
-
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz"
@@ -5354,7 +5507,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.0, get-stream@^6.0.1:
+get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -5768,26 +5921,10 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-human-signals@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
-  integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
-
-husky@4:
-  version "4.3.8"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.8.tgz#31144060be963fd6850e5cc8f019a1dfe194296d"
-  integrity sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==
-  dependencies:
-    chalk "^4.0.0"
-    ci-info "^2.0.0"
-    compare-versions "^3.6.0"
-    cosmiconfig "^7.0.0"
-    find-versions "^4.0.0"
-    opencollective-postinstall "^2.0.2"
-    pkg-dir "^5.0.0"
-    please-upgrade-node "^3.2.0"
-    slash "^3.0.0"
-    which-pm-runs "^1.0.0"
+husky@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
 
 hyphen@^1.6.4:
   version "1.6.4"
@@ -5800,6 +5937,13 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
@@ -5921,6 +6065,11 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 io-ts@1.10.4:
   version "1.10.4"
@@ -6090,11 +6239,6 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-fullwidth-code-point@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
-  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
-
 is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz"
@@ -6213,11 +6357,6 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
-
-is-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
-  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -7179,11 +7318,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lilconfig@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.5.tgz#19e57fd06ccc3848fd1891655b5a447092225b25"
-  integrity sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==
-
 lilconfig@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz"
@@ -7193,39 +7327,6 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
-
-lint-staged@^13.0.3:
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.0.3.tgz#d7cdf03a3830b327a2b63c6aec953d71d9dc48c6"
-  integrity sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==
-  dependencies:
-    cli-truncate "^3.1.0"
-    colorette "^2.0.17"
-    commander "^9.3.0"
-    debug "^4.3.4"
-    execa "^6.1.0"
-    lilconfig "2.0.5"
-    listr2 "^4.0.5"
-    micromatch "^4.0.5"
-    normalize-path "^3.0.0"
-    object-inspect "^1.12.2"
-    pidtree "^0.6.0"
-    string-argv "^0.3.1"
-    yaml "^2.1.1"
-
-listr2@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-4.0.5.tgz#9dcc50221583e8b4c71c43f9c7dfd0ef546b75d5"
-  integrity sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==
-  dependencies:
-    cli-truncate "^2.1.0"
-    colorette "^2.0.16"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rfdc "^1.3.0"
-    rxjs "^7.5.5"
-    through "^2.3.8"
-    wrap-ansi "^7.0.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -7249,13 +7350,6 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
-
-locate-path@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
-  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
-  dependencies:
-    p-locate "^5.0.0"
 
 lodash-id@^0.14.1:
   version "0.14.1"
@@ -7288,16 +7382,6 @@ log-symbols@3.0.0:
   integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
   dependencies:
     chalk "^2.4.2"
-
-log-update@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
-  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
-  dependencies:
-    ansi-escapes "^4.3.0"
-    cli-cursor "^3.1.0"
-    slice-ansi "^4.0.0"
-    wrap-ansi "^6.2.0"
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -7513,14 +7597,6 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-micromatch@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
-  dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
-
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz"
@@ -7555,11 +7631,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mimic-fn@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
-  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -7874,13 +7945,6 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npm-run-path@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
-  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
-  dependencies:
-    path-key "^4.0.0"
-
 npmlog@^4.0.1:
   version "4.1.2"
   resolved "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz"
@@ -7924,11 +7988,6 @@ object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.12.0"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
-
-object-inspect@^1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
-  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -8045,24 +8104,12 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0, onetime@^5.1.2:
+onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-onetime@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
-  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
-  dependencies:
-    mimic-fn "^4.0.0"
-
-opencollective-postinstall@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
-  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 optimism@^0.16.1:
   version "0.16.1"
@@ -8130,13 +8177,6 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
-  dependencies:
-    yocto-queue "^0.1.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
@@ -8157,20 +8197,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-locate@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
-  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
-  dependencies:
-    p-limit "^3.0.2"
-
-p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
-  dependencies:
-    aggregate-error "^3.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -8294,11 +8320,6 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-key@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
-  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
-
 path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
@@ -8352,15 +8373,10 @@ picocolors@^1.0.0:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-pidtree@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
-  integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
 pify@^3.0.0:
   version "3.0.0"
@@ -8378,13 +8394,6 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -8962,14 +8971,6 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
-  dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-
 restructure@^0.5.3:
   version "0.5.4"
   resolved "https://registry.npmjs.org/restructure/-/restructure-0.5.4.tgz"
@@ -8986,11 +8987,6 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
-rfdc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
-  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rgbcolor@^1.0.1:
   version "1.0.1"
@@ -9026,6 +9022,11 @@ rlp@^2.2.3, rlp@^2.2.4:
   dependencies:
     bn.js "^5.2.0"
 
+robust-predicates@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.1.tgz#ecde075044f7f30118682bd9fb3f123109577f9a"
+  integrity sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g==
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz"
@@ -9043,12 +9044,10 @@ rustbn.js@~0.2.0:
   resolved "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
-rxjs@^7.5.5:
-  version "7.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
-  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
-  dependencies:
-    tslib "^2.1.0"
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -9072,7 +9071,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -9145,11 +9144,6 @@ semver-diff@^3.1.1:
   integrity sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
   dependencies:
     semver "^6.3.0"
-
-semver-regex@^3.1.2:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.4.tgz#13053c0d4aa11d070a2f2872b6b1e3ae1e1971b4"
-  integrity sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==
 
 semver@^5.5.0, semver@^5.7.0:
   version "5.7.1"
@@ -9301,7 +9295,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -9337,15 +9331,6 @@ slash@^3.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz"
@@ -9354,14 +9339,6 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
-
-slice-ansi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
-  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
-  dependencies:
-    ansi-styles "^6.0.0"
-    is-fullwidth-code-point "^4.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -9567,11 +9544,6 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
-string-argv@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
-  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -9614,15 +9586,6 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
-
-string-width@^5.0.0:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
-  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
-  dependencies:
-    eastasianwidth "^0.2.0"
-    emoji-regex "^9.2.2"
-    strip-ansi "^7.0.1"
 
 string.prototype.matchall@^4.0.6:
   version "4.0.6"
@@ -9696,13 +9659,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
-  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
-  dependencies:
-    ansi-regex "^6.0.1"
-
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
@@ -9729,11 +9685,6 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-
-strip-final-newline@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
-  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-hex-prefix@1.0.0:
   version "1.0.0"
@@ -9956,7 +9907,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3", through@^2.3.8, through@~2.3.4:
+"through@>=2.2.7 <3", through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
@@ -10505,11 +10456,6 @@ which-module@^2.0.0:
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which-pm-runs@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.1.0.tgz#35ccf7b1a0fce87bd8b92a478c9d045785d3bf35"
-  integrity sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==
-
 which-typed-array@^1.1.2:
   version "1.1.7"
   resolved "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz"
@@ -10563,15 +10509,6 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
-
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -10657,11 +10594,6 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
-  integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
-
 yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz"
@@ -10730,11 +10662,6 @@ yargs@^17.0.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
-
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
-  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
 zen-observable-ts@^0.8.21:
   version "0.8.21"


### PR DESCRIPTION
Brings back split - price contracts and updates contract names.
Closes #728  Add's ability to mint fixed tiered bounty. I've hidden the option from the user atm, because it looks like some backend and design changes might be needed to accommodate it.
Closes #730, see image:
![image](https://user-images.githubusercontent.com/72156679/191164480-4dc8fee2-c910-4967-8716-2405015b1a2d.png)
Closes #724, allows user to attempt refund on closed split contracts and contests.
Closes #729 See image:
![image](https://user-images.githubusercontent.com/72156679/191488881-4eb1adbf-390b-4fb9-bf0e-377c4a55a29d.png)

Closes #725, makes each tab of view page a panels for the specific tabs topic that are the same time + the bounty Metadata component. See screenshots below:
![image](https://user-images.githubusercontent.com/72156679/191164952-cb97fb86-46d6-4301-a5e4-bd562202ef32.png)
![image](https://user-images.githubusercontent.com/72156679/191164937-b02fa9cd-94c6-4a35-8a2f-089427179030.png)
![image](https://user-images.githubusercontent.com/72156679/191164977-41b1b479-8108-4ad0-b825-fb201a0fb07a.png)
![image](https://user-images.githubusercontent.com/72156679/191165081-93574717-a100-455f-b168-7ad4f6fec7b0.png)
![image](https://user-images.githubusercontent.com/72156679/191165593-b30cfafe-7e54-42ae-afd6-39cf45ac9f6b.png)




