### PR TITLE
Target blank

### DIFF
--- a/__tests__/Bounty/MiniDepositCard.test.js
+++ b/__tests__/Bounty/MiniDepositCard.test.js
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '../../test-utils';
+import MiniDepositCard from '../../components/Bounty/MiniDepositCard';
+
+describe('MiniDepositCard', () => {
+  it('should render MiniDepositCard', async () => {
+    const deposit = {
+      __typename: 'Deposit',
+      id: '0xd024e550ba670d71f23f336c63ed0aacda946c6836f416028ffa0888b1a4b691',
+      refunded: false,
+      refundTime: null,
+      expiration: '2592000',
+      tokenAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
+      bounty: {
+        bountyId: 'I_kwDOGWnnz85I9Ahl',
+      },
+      volume: '12000000000000000000',
+      sender: {
+        __typename: 'User',
+        id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      },
+      receiveTime: '1642021044',
+    };
+    // ARRANGE
+    render(<MiniDepositCard deposit={deposit} showLink={true} />);
+
+    // ASSERT
+
+    expect(await screen.findByText(/12.00 LINK/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Good first issue/i)).toBeInTheDocument();
+
+    // should not have null or undefined values
+    const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+    expect(nullish).toHaveLength(0);
+  });
+});

--- a/__tests__/Bounty/PieChart.test.js
+++ b/__tests__/Bounty/PieChart.test.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '../../test-utils';
+import PieChart from '../../components/Bounty/PieChart';
+
+describe('PieChart', () => {
+  it('should render PieChart', async () => {
+    // ARRANGE
+    render(<PieChart payoutSchedule={[20, 30, 40]} />);
+
+    // ASSERT
+
+    expect(await screen.findByText(/20%/i)).toBeInTheDocument();
+    expect(await screen.findByText(/30%/i)).toBeInTheDocument();
+    expect(await screen.findByText(/40%/i)).toBeInTheDocument();
+
+    // should not have null or undefined values
+    const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+    expect(nullish).toHaveLength(0);
+  });
+});

--- a/__tests__/BountyCard/BountyModalHeading.test.js
+++ b/__tests__/BountyCard/BountyModalHeading.test.js
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+
+import { render, screen } from '../../test-utils';
+import BountyModalHeading from '../../components/BountyCard/BountyModalHeading';
+
+describe('BountyModalHeading', () => {
+  it('should render BountyModalHeading', async () => {
+    const bounty = {
+      id: 'I_kwDOGWnnz85GjwA1',
+      title: 'Properly Referenced and Merged by FlacoJones',
+      assignees: [
+        {
+          __typename: 'User',
+          name: 'Christopher Stevers',
+          login: 'Christopher-Stevers',
+          url: 'https://github.com/Christopher-Stevers',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/72156679?u=7e821e3f2a1f88c0f4a134eec159189f9c3e7367&v=4',
+        },
+      ],
+      body: '',
+      url: 'https://github.com/OpenQDev/OpenQ-TestRepo/issues/136',
+      repoName: 'OpenQ-TestRepo',
+      closedAt: '2022-03-28T17:57:44Z',
+      owner: 'OpenQDev',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/77402538?v=4',
+      labels: [],
+      createdAt: '2022-03-28T17:46:36Z',
+      closed: true,
+      bodyHTML: '',
+      titleHTML: 'Properly Referenced and Merged by FlacoJones',
+      twitterUsername: 'openqlabs',
+      number: 136,
+      prs: [
+        {
+          __typename: 'CrossReferencedEvent',
+          referencedAt: '2022-03-28T17:47:26Z',
+          source: {
+            __typename: 'PullRequest',
+            mergedAt: '2022-03-28T17:57:44Z',
+            url: 'https://github.com/OpenQDev/OpenQ-TestRepo/pull/138',
+            merged: true,
+            title: 'Update README.md',
+            author: {
+              __typename: 'User',
+              login: 'FlacoJones',
+              avatarUrl:
+                'https://avatars.githubusercontent.com/u/93455288?u=fd1fb04b6ff2bf397f8353eafffc3bfb4bd66e84&v=4',
+              url: 'https://github.com/FlacoJones',
+            },
+            mergeCommit: {
+              __typename: 'Commit',
+              author: {
+                __typename: 'GitActor',
+                avatarUrl: 'https://avatars.githubusercontent.com/u/93455288?v=4',
+                name: 'FlacoJones',
+                user: { __typename: 'User', login: 'FlacoJones', url: 'https://github.com/FlacoJones' },
+              },
+            },
+          },
+        },
+      ],
+      closedEvents: [
+        {
+          __typename: 'ClosedEvent',
+          id: 'CE_lADOGWnnz85GjwA1zwAAAAF4vHFc',
+          actor: {
+            __typename: 'User',
+            avatarUrl:
+              'https://avatars.githubusercontent.com/u/93455288?u=fd1fb04b6ff2bf397f8353eafffc3bfb4bd66e84&v=4',
+            login: 'FlacoJones',
+            url: 'https://github.com/FlacoJones',
+            name: null,
+          },
+        },
+      ],
+      __typename: 'Bounty',
+      tvl: 9.51848,
+      bountyId: 'I_kwDOGWnnz85GjwA1',
+      bountyAddress: '0x29bdcbc116f3775698ae0ffe5f8fbbaf95f240cf',
+      closerData: null,
+      bountyMintTime: '1662545344',
+      bountyClosedTime: null,
+      fundingGoalVolume: '100',
+      fundingGoalTokenAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
+      payoutTokenVolume: null,
+      payoutTokenAddress: null,
+      payoutSchedule: null,
+      claims: [],
+      payouts: [],
+      claimedTransactionHash: null,
+      payoutAddress: null,
+      status: '0',
+      bountyType: '0',
+      closer: null,
+      deposits: [
+        {
+          id: '0xe5551a3fa87d93a0c6c084d572b9e282114befc43dc68f08be6d53d13830e356',
+          refunded: false,
+          receiveTime: '1662545374',
+          tokenAddress: '0x0000000000000000000000000000000000000000',
+          expiration: '1296000',
+          volume: '1000000000000000000',
+          refundTime: null,
+          sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+          __typename: 'Deposit',
+        },
+        {
+          id: '0xb4f31aab8a1c4bfe26236729e8cd8e4abf81d63283e006b4ec677a7ce6b2871a',
+          refunded: true,
+          receiveTime: '1662545373',
+          tokenAddress: '0xe7f1725e7734ce288f8367e1bb143e90bb3f0512',
+          expiration: '30',
+          volume: '2000000000000000000',
+          refundTime: '1662559726',
+          sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+          __typename: 'Deposit',
+        },
+        {
+          id: '0x7db2691e573b9c19e90f391cd3eda9ce9246666a1502f2bf87b9d47d13679bc0',
+          refunded: false,
+          receiveTime: '1662545372',
+          tokenAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
+          expiration: '1296000',
+          volume: '1000000000000000000',
+          refundTime: null,
+          sender: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+          __typename: 'Deposit',
+        },
+      ],
+      refunds: [
+        {
+          refundTime: '1662559726',
+          tokenAddress: '0xe7f1725e7734ce288f8367e1bb143e90bb3f0512',
+          volume: '2000000000000000000',
+          __typename: 'Refund',
+        },
+      ],
+      bountyTokenBalances: [
+        {
+          tokenAddress: '0x0000000000000000000000000000000000000000',
+          volume: '1000000000000000000',
+          __typename: 'BountyFundedTokenBalance',
+        },
+        {
+          tokenAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
+          volume: '1000000000000000000',
+          __typename: 'BountyFundedTokenBalance',
+        },
+      ],
+      issuer: { id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', __typename: 'User' },
+    };
+    const closeModal = () => {
+      return null;
+    };
+    // ARRANGE
+    render(<BountyModalHeading bounty={bounty} closeModal={closeModal} unWatchable={true} watchingState={undefined} />);
+
+    // ASSERT
+
+    expect(screen.getByText(/Full Contract Details/i)).toBeInTheDocument();
+    expect(screen.getByText(/OpenQ-TestRepo/i)).toBeInTheDocument();
+    expect(screen.getByText(/OpenQDev/i)).toBeInTheDocument();
+    expect(screen.getByText(/Properly Referenced and Merged by FlacoJones/i)).toBeInTheDocument();
+    expect(screen.getByRole('img')).toBeInTheDocument();
+    // should not have null or undefined values
+    const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+    expect(nullish).toHaveLength(0);
+  });
+});

--- a/components/Bounty/CarouselBounty.js
+++ b/components/Bounty/CarouselBounty.js
@@ -6,9 +6,11 @@ import ToolTipNew from '../Utils/ToolTipNew';
 import Link from 'next/link';
 import { PersonAddIcon, PersonIcon, PeopleIcon } from '@primer/octicons-react';
 import LabelsList from '../Bounty/LabelsList';
+import useAuth from '../../hooks/useAuth';
 
 const CarouselBounty = ({ bounty }) => {
   const [appState] = useContext(StoreContext);
+  const [authState] = useAuth();
 
   const createBudget = (bounty) => {
     return bounty.fundingGoalTokenAddress
@@ -22,9 +24,9 @@ const CarouselBounty = ({ bounty }) => {
   const [budgetValue] = useGetTokenValues(budgetObj);
   const budget = budgetValue?.total;
 
-  //	const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances);
-  const price = 10; //tokenValues?.total;
-
+  const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances);
+  const price = tokenValues?.total;
+  const bountyMarker = appState.utils.getBountyMarker(bounty, authState.login);
   return (
     <>
       <Link
@@ -41,7 +43,7 @@ const CarouselBounty = ({ bounty }) => {
               <div className='pt-1'>
                 <svg
                   xmlns='http://www.w3.org/2000/svg'
-                  fill={bounty?.STATUS === 'CLOSED' ? '#F0431D' : '#15FB31'}
+                  className={bountyMarker.fill}
                   viewBox='0 0 16 16'
                   width='19'
                   height='19'
@@ -93,7 +95,7 @@ const CarouselBounty = ({ bounty }) => {
                       >
                         <path d='M1.679 7.932c.412-.621 1.242-1.75 2.366-2.717C5.175 4.242 6.527 3.5 8 3.5c1.473 0 2.824.742 3.955 1.715 1.124.967 1.954 2.096 2.366 2.717a.119.119 0 010 .136c-.412.621-1.242 1.75-2.366 2.717C10.825 11.758 9.473 12.5 8 12.5c-1.473 0-2.824-.742-3.955-1.715C2.92 9.818 2.09 8.69 1.679 8.068a.119.119 0 010-.136zM8 2c-1.981 0-3.67.992-4.933 2.078C1.797 5.169.88 6.423.43 7.1a1.619 1.619 0 000 1.798c.45.678 1.367 1.932 2.637 3.024C4.329 13.008 6.019 14 8 14c1.981 0 3.67-.992 4.933-2.078 1.27-1.091 2.187-2.345 2.637-3.023a1.619 1.619 0 000-1.798c-.45-.678-1.367-1.932-2.637-3.023C11.671 2.992 9.981 2 8 2zm0 8a2 2 0 100-4 2 2 0 000 4z'></path>
                       </svg>
-                      <span>{0}</span>
+                      <span>{bounty.watchingCount}</span>
                     </span>
                   </div>
                   <div className=''>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -532,7 +532,7 @@ const MintBountyModal = ({ modalVisibility, hideSubmenu, types }) => {
                     'https://github.com/OpenQDev/OpenQ-Contracts/blob/production/contracts/Bounty/Implementations/BountyV1.sol'
                   }
                 >
-                  <a className='flex content-center gap-2 underline px-8'>
+                  <a target={'_blank'} rel='noopener noreferrer' className='flex content-center gap-2 underline px-8'>
                     <Image src={'/social-icons/github-logo-white.svg'} width={24} height={24} />
                     Contract source code
                   </a>

--- a/services/openq-api/graphql/query.js
+++ b/services/openq-api/graphql/query.js
@@ -84,6 +84,7 @@ export const GET_USER_BY_HASH = gql`
           tvl
           address
           bountyId
+          watchingCount
         }
       }
       starredOrganizationIds


### PR DESCRIPTION
Closes #734 
Adds target blank to contract source code button.
Closes #732 watched issues were getting there status colour from the wrong place before, gave them the same source as everything else.
Also added tests for minidepositcard, piechar tand bountymodalheading.
![image](https://user-images.githubusercontent.com/72156679/191532248-cf8ed0c1-0c5d-43b0-9e94-fae743993db9.png)
