### PR TITLE
Solve bug of bounty page not showing when refunded

### DIFF
--- a/components/Utils/ActionBubble.js
+++ b/components/Utils/ActionBubble.js
@@ -156,7 +156,7 @@ const ActionBubble = ({ addresses, bounty, action }) => {
       <div className='w-full flex-0 rounded-sm overflow-hidden ml-4 border-web-gray border-b before:w-2 before:h-2 before:bg-nav-bg before:absolute before:absolute before:left-12 before:top-[34px] before:border-b  before:border-l before:border-web-gray before:rotate-45  border'>
         <div className={`bg-nav-bg w-full pl-3 ${!action && 'border-web-gray'} flex justify-between`}>
           <span className='py-2'>
-            <span data-testid='actionTitle'>{tokenValues || titlePartOne}</span>
+            <span data-testid='actionTitle'>{titlePartOne}</span>
             {action?.url && (
               <a className='inline underline' href={action.url}>
                 {action.title}

--- a/components/Utils/ActionBubble.js
+++ b/components/Utils/ActionBubble.js
@@ -103,7 +103,7 @@ const ActionBubble = ({ addresses, bounty, action }) => {
   }
 
   if (action?.receiveTime || action?.refundTime) {
-    const funder = senderEnsName || shortenAddress(action.sender.id);
+    const funder = senderEnsName || shortenAddress(action.sender?.id);
     address = action.sender?.id || bounty.issuer.id;
     const { volume } = action;
     const tokenMetadata = appState.tokenClient.getToken(action.tokenAddress);

--- a/components/Utils/ActionBubble.js
+++ b/components/Utils/ActionBubble.js
@@ -103,7 +103,8 @@ const ActionBubble = ({ addresses, bounty, action }) => {
   }
 
   if (action?.receiveTime || action?.refundTime) {
-    const funder = senderEnsName || shortenAddress(action.sender?.id);
+    const refunder = bounty.deposits.filter((deposit) => deposit.id === action.depositId)[0]?.sender?.id;
+    const funder = senderEnsName || shortenAddress(action.sender?.id) || shortenAddress(refunder);
     address = action.sender?.id || bounty.issuer.id;
     const { volume } = action;
     const tokenMetadata = appState.tokenClient.getToken(action.tokenAddress);
@@ -155,9 +156,7 @@ const ActionBubble = ({ addresses, bounty, action }) => {
       <div className='w-full flex-0 rounded-sm overflow-hidden ml-4 border-web-gray border-b before:w-2 before:h-2 before:bg-nav-bg before:absolute before:absolute before:left-12 before:top-[34px] before:border-b  before:border-l before:border-web-gray before:rotate-45  border'>
         <div className={`bg-nav-bg w-full pl-3 ${!action && 'border-web-gray'} flex justify-between`}>
           <span className='py-2'>
-            <span data-testid='actionTitle'>
-              {tokenValues || (!action?.receiveTime && !action?.refundTime) ? titlePartOne : <Skeleton width='34' />}
-            </span>
+            <span data-testid='actionTitle'>{tokenValues || titlePartOne}</span>
             {action?.url && (
               <a className='inline underline' href={action.url}>
                 {action.title}

--- a/services/subgraph/graphql/query.js
+++ b/services/subgraph/graphql/query.js
@@ -132,6 +132,7 @@ export const GET_BOUNTY = gql`
         refundTime
         tokenAddress
         volume
+        depositId
       }
       bountyTokenBalances {
         tokenAddress


### PR DESCRIPTION
closes #757 
Related to https://github.com/OpenQDev/OpenQ-Graph/issues/4 as for some reason the staging Subgraph is not showing refund.sender.id

Page should now show normally again and also the content of the refunded:
![image](https://user-images.githubusercontent.com/75732239/191945095-5568370e-9216-407c-b4cf-c1ad89aa58e8.png)



