### PR TITLE
Non-Profit page & miscellaneous

### DIFF
--- a/components/Bounty/BountyHomepage.js
+++ b/components/Bounty/BountyHomepage.js
@@ -44,7 +44,6 @@ const BountyHomepage = ({
             complete={complete}
             getNewData={getNewData}
             wizard={wizard}
-            category={category}
             types={types}
             contractToggle={contractToggle}
           />

--- a/components/BountyList/BountyList.js
+++ b/components/BountyList/BountyList.js
@@ -27,14 +27,13 @@ const BountyList = ({
   contractToggle,
   wizard,
   types,
-  category,
 }) => {
   // Hooks
   const { account } = useWeb3();
   const [appState] = useContext(StoreContext);
   const router = useRouter();
   const [searchText, updateSearchText] = useState(
-    `order:newest ${router.query.type && category !== 'non-profit' ? `type:"${router.query.type}"` : ''}`
+    `order:newest ${router.query.type ? `type:"${router.query.type}"` : ''}`
   );
   const [tagArr, updateTagArr] = useState([]);
   const [searchedBounties, updateSearchedBounties] = useState([]);
@@ -103,12 +102,6 @@ const BountyList = ({
     }
   }, [bounties]);
   // NOTE tag search doesn't turn off regular search, it just manages it a little differently.
-
-  useEffect(() => {
-    if (category === 'non-profit') {
-      addLabel('non-profit');
-    }
-  }, [category]);
 
   const filter = (bounties, options = {}) => {
     const localTagArr = options.tagArr || tagArr;
@@ -397,6 +390,7 @@ const BountyList = ({
           {searchedBounties.map((bounty, index) => {
             return (
               <div key={bounty.id} ref={index === searchedBounties.length - 1 ? lastElem : null}>
+                {console.log(bounty.category)}
                 <BountyCardLean index={index} length={searchedBounties.length} bounty={bounty} />
               </div>
             );

--- a/components/BountyList/BountyList.js
+++ b/components/BountyList/BountyList.js
@@ -27,15 +27,14 @@ const BountyList = ({
   contractToggle,
   wizard,
   types,
+  category,
 }) => {
   // Hooks
   const { account } = useWeb3();
   const [appState] = useContext(StoreContext);
   const router = useRouter();
   const [searchText, updateSearchText] = useState(
-    `order:newest ${
-      router.query.type && router.route === '/organization/[organization]' ? `type:"${router.query.type}"` : ''
-    }`
+    `order:newest ${router.query.type && category !== 'non-profit' ? `type:"${router.query.type}"` : ''}`
   );
   const [tagArr, updateTagArr] = useState([]);
   const [searchedBounties, updateSearchedBounties] = useState([]);
@@ -104,6 +103,13 @@ const BountyList = ({
     }
   }, [bounties]);
   // NOTE tag search doesn't turn off regular search, it just manages it a little differently.
+
+  useEffect(() => {
+    if (category === 'non-profit') {
+      addLabel('non-profit');
+    }
+  }, [category]);
+
   const filter = (bounties, options = {}) => {
     const localTagArr = options.tagArr || tagArr;
     const localSearchText = options.searchText === undefined ? searchText : options.searchText;
@@ -247,8 +253,15 @@ const BountyList = ({
     updateSearchedBounties(orderBounties(filter(bounties, { searchText: e.target.value })));
   };
   const addLabel = (label) => {
-    updateSearchText(`${searchText} label:"${label}"`);
-    updateSearchedBounties(orderBounties(filter(bounties, { searchText: `${searchText} label:"${label}"` })));
+    if (!searchText.includes(label)) {
+      updateSearchText(`${searchText} label:"${label}"`);
+      updateSearchedBounties(orderBounties(filter(bounties, { searchText: `${searchText} label:"${label}"` })));
+    } else {
+      updateSearchText(`${searchText.replace(`label:"${label}"`, '').trimEnd()} `);
+      updateSearchedBounties(
+        orderBounties(filter(bounties, { searchText: `${searchText.replace(`label:"${label}"`, '')}` }))
+      );
+    }
   };
 
   const setContractType = (type) => {

--- a/components/BountyList/BountyList.js
+++ b/components/BountyList/BountyList.js
@@ -134,6 +134,7 @@ const BountyList = ({
         ) || searchedLabels.length === 0;
 
       const isType = types.some((type) => type === bounty.bountyType);
+      const isNonProfit = router.query.type === 'non-profit' ? bounty.category === 'non-profit' : true;
       let containsSearch = true;
 
       try {
@@ -170,7 +171,8 @@ const BountyList = ({
           hasLabels &&
           bounty.url &&
           !bounty.blacklisted &&
-          isType
+          isType &&
+          isNonProfit
         );
       } catch (err) {
         appState.logger.error(err);

--- a/components/Layout/NavLinks.js
+++ b/components/Layout/NavLinks.js
@@ -19,6 +19,10 @@ const NavLinks = () => {
       <Link href={'/contests'}>
         <a className={`nav-link $ ${router.asPath === '/contests' && 'text-white'}`}>Contests</a>
       </Link>
+
+      <Link href={'/non-profit'}>
+        <a className={`nav-link $ ${router.asPath === '/non-profit' && 'text-white'}`}>Non-Profit</a>
+      </Link>
     </>
   );
 };

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -14,7 +14,6 @@ import { ThreeBarsIcon } from '@primer/octicons-react';
 import LinkDropdown from '../Utils/LinkDropdown';
 import { useRouter } from 'next/router';
 import NavLinks from './NavLinks';
-import ContractWizard from '../ContractWizard/ContractWizard';
 import OpenQSocials from './OpenQSocials';
 import LoadingBar from '../Loading/LoadingBar';
 import LoadingThread from '../Loading/LoadingThread.js';
@@ -28,7 +27,6 @@ const Navigation = () => {
   const [quickSearch, setQuickSearch] = useState('');
   const [items, setItems] = useState([]);
   const [searchable, setSearchable] = useState();
-  const [showWizard, setShowWizard] = useState(false);
   const [loadingBar, setLoadingBar] = useState(false);
   const [changeText, setChangeText] = useState(false);
   const { bountyMinted, authService, openQSubgraphClient, openQPrismaClient, utils, githubRepository, tokenClient } =
@@ -151,11 +149,7 @@ const Navigation = () => {
   return (
     <div className='bg-nav-bg py-1 '>
       <FirstTimeBanner />
-
       <LoadingThread />
-
-      {/* Desktop view */}
-
       <div className='flex visible relative'>
         <div className='flex w-full lg:py-1 justify-between mx-8'>
           <div className='flex space-x-5 items-center'>
@@ -182,12 +176,6 @@ const Navigation = () => {
                 {quickSearch && <LinkDropdown items={items} />}
               </div>
               <NavLinks />
-              <button onClick={() => setShowWizard(true)}>
-                <div className='mx-2 text-[0.8rem] tracking-wider md:hover:text-primary text-muted font-bold hover:cursor-pointer'>
-                  Contract Wizard
-                </div>
-              </button>
-              {showWizard && <ContractWizard wizardVisibility={setShowWizard} />}
             </div>
           </div>
           <div className='flex items-center text-[0.8rem] lg:text-[1rem]'>
@@ -213,15 +201,7 @@ const Navigation = () => {
               ></input>
               {quickSearch && <LinkDropdown items={items} />}
             </div>
-
             <NavLinks />
-
-            <button onClick={() => setShowWizard(true)}>
-              <div className='flex text-[0.8rem] pt-1 border-t border-gray-700 tracking-wider text-nav-text font-bold'>
-                Contract Wizard
-              </div>
-            </button>
-            {showWizard && <ContractWizard wizardVisibility={setShowWizard} />}
           </div>
         </div>
       ) : null}

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -14,7 +14,6 @@ import { ThreeBarsIcon } from '@primer/octicons-react';
 import LinkDropdown from '../Utils/LinkDropdown';
 import { useRouter } from 'next/router';
 import NavLinks from './NavLinks';
-import OpenQSocials from './OpenQSocials';
 import LoadingBar from '../Loading/LoadingBar';
 import LoadingThread from '../Loading/LoadingThread.js';
 
@@ -205,7 +204,6 @@ const Navigation = () => {
           </div>
         </div>
       ) : null}
-      <OpenQSocials />
       {loadingBar && <LoadingBar loadingBar={setLoadingBar} changeText={changeText} />}
     </div>
   );

--- a/pages/[type].js
+++ b/pages/[type].js
@@ -124,10 +124,9 @@ export default function Index({ orgs, fullBounties, batch, types, category, rend
         {error ? (
           <UnexpectedError error={error} />
         ) : internalMenu == 'Organizations' ? (
-          <OrganizationHomepage orgs={controlledOrgs} types={types} category={category} />
+          <OrganizationHomepage orgs={controlledOrgs} types={types} />
         ) : (
           <BountyHomepage
-            category={category}
             bounties={bounties}
             watchedBounties={watchedBounties}
             loading={isLoading}

--- a/pages/[type].js
+++ b/pages/[type].js
@@ -135,6 +135,7 @@ export default function Index({ orgs, fullBounties, batch, types, category, rend
             complete={complete}
             getNewData={getNewData}
             types={types}
+            wizard={category === 'non-profit'}
           />
         )}
       </div>
@@ -157,6 +158,10 @@ export const getServerSideProps = async (ctx) => {
     case 'split-price':
       category = 'learn2earn';
       types = ['1'];
+      break;
+    case 'non-profit':
+      category = 'non-profit';
+      types = ['0', '1', '2', '3'];
       break;
   }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -50,7 +50,7 @@ function OpenQ({ Component, pageProps }) {
         <meta name='OpenQ Bounties' content='width=device-width, initial-scale=1.0' />
         <link rel='icon' href='/openq-logo.png' />
         <link rel='manifest' href='/manifest.json' />
-        <script type='text/javascript'>
+        <Script type='text/javascript' strategy='lazyOnload'>
           {`window['__ls_namespace'] = 'LiveSession';
     window['__ls_script_url'] = 'https://cdn.livesession.io/track.js';
     !function(w, d, t, u, n) {
@@ -74,7 +74,7 @@ function OpenQ({ Component, pageProps }) {
             })
         }
     });`}
-        </script>
+        </Script>
       </Head>
       <>
         <AuthProvider>


### PR DESCRIPTION
closes #781 but did not do any OpenQ-API modifications - I didn't see the need, but since I'm unfamiliar with the API so far, my solution might be too simplistic...?

Non-Profit page:
- Removes the contract wizard navigation link and replaces it with the "non-profit" category
- Uses addLabel to filter the shown issues by 'non-profit' GitHub label
- Adjusts for the MintBountyButton on non-profit page to show the contract wizard

Other Search Field related changes:
- shows "type: ..." in searchfield (previous condition was hiding it)
- modifying addLabel to remove a label when clicked and already in the searchText (previously kept adding more of the same label)

Miscellaneous:
- Also adds lazyOnload for LiveSession script

![image](https://user-images.githubusercontent.com/75732239/193780247-644217a3-8ec3-416c-aa0f-cb309ed81504.png)

![image](https://user-images.githubusercontent.com/75732239/193783101-a8e16b2d-95f0-4311-b8d8-c476838b0cc2.png)

