### PR TITLE
Misc: Minor Fixes

### DIFF
--- a/components/BountyCard/BountyCardLean.js
+++ b/components/BountyCard/BountyCardLean.js
@@ -200,7 +200,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
                   <div className='whitespace-nowrap'>{bountyTypeName}</div>
                 </span>
 
-                {tokenValues?.total > budget ? (
+                {tokenValues?.total >= budget ? (
                   <div className='flex flex-row space-x-1 w-min items-center'>
                     <div className='pr-2 pt-1 w-4'>
                       <Image src='/crypto-logos/ETH-COLORED.png' alt='avatarUrl' width='12' height='20' />

--- a/components/BountyList/BountyList.js
+++ b/components/BountyList/BountyList.js
@@ -392,7 +392,6 @@ const BountyList = ({
           {searchedBounties.map((bounty, index) => {
             return (
               <div key={bounty.id} ref={index === searchedBounties.length - 1 ? lastElem : null}>
-                {console.log(bounty.category)}
                 <BountyCardLean index={index} length={searchedBounties.length} bounty={bounty} />
               </div>
             );

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -40,10 +40,10 @@ const ClaimOverview = ({ bounty, setInternalMenu }) => {
   const [sum, setSum] = useState({});
 
   const changeObj = (claimant, value) => {
-    if (claimant in sum && value) {
+    if (claimant in sum && value >= 0) {
       setSum((prev) => ({ ...prev, [claimant]: prev[claimant] + value }));
     }
-    if (!(claimant in sum) && value) {
+    if (!(claimant in sum) && value >= 0) {
       setSum((prev) => ({ ...prev, [claimant]: value }));
     }
   };

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -96,7 +96,11 @@ const ClaimOverview = ({ bounty, setInternalMenu }) => {
         {bounty.payouts?.length ? (
           <div className={`flex flex-col pb-6 ${tokenAddresses.length > 1 ? '' : 'w-full'}`}>
             <div
-              className={`grid ${tokenAddresses.length > 1 ? 'grid-cols-[250px_1fr_172px]' : 'grid-cols-[1fr_250px]'}`}
+              className={`grid ${
+                tokenAddresses.length > 1
+                  ? 'grid-cols-[250px_1fr_172px]'
+                  : 'grid-cols-[140px_250px] sm:grid-cols-[1fr_250px]'
+              }`}
             >
               <div className='px-2 pb-2'></div>
               <div className='grid grid-flow-col auto-cols-fr'>
@@ -114,12 +118,14 @@ const ClaimOverview = ({ bounty, setInternalMenu }) => {
                   {switchType(type)}
                   <div
                     className={`grid ${
-                      tokenAddresses.length > 1 ? 'grid-cols-[250px_1fr]' : 'grid-cols-[1fr_250px]'
+                      tokenAddresses.length > 1
+                        ? 'grid-cols-[250px_1fr]'
+                        : 'grid-cols-[140px_250px] sm:grid-cols-[1fr_250px]'
                     } ${styles}`}
                   >
                     <div className=''>
                       {type === 'refundable' || type === 'total' ? (
-                        <div className='flex gap-1 items-center whitespace-nowrap'>
+                        <div className='flex gap-1 items-center sm:whitespace-nowrap'>
                           {title}
                           <ToolTipNew
                             relativePosition={'-left-5'}

--- a/components/Claim/ClaimOverview.js
+++ b/components/Claim/ClaimOverview.js
@@ -159,7 +159,7 @@ const ClaimOverview = ({ bounty, setInternalMenu }) => {
                       {tokenAddresses.length > 1 && (
                         <div className='grid grid-cols-[1fr_1fr] px-2 pb-2'>
                           <div className='flex justify-end self-center px-1 mr-1 whitespace-nowrap w-14'>
-                            {((sum[type] / totalDepositValue) * 100).toFixed(0)} %
+                            {totalDepositValue > 0 ? ((sum[type] / totalDepositValue) * 100).toFixed(0) : 'n.a.'} %
                           </div>
                           <div className='flex justify-start self-center px-1 whitespace-nowrap w-24'>
                             {appState.utils.formatter.format(sum[type])}

--- a/components/Claim/ClaimPerToken.js
+++ b/components/Claim/ClaimPerToken.js
@@ -26,7 +26,7 @@ const ClaimPerToken = ({ bounty, tokenAddress, claimant, type, changeObj }) => {
   );
   const [claimantBalances] = useGetTokenValues(claimantBalancesObj);
   const claimantVolume = formatVolume(claimantBalancesObj?.volume || 0);
-  const claimantValue = claimantBalances?.total;
+  const claimantValue = claimantBalances?.total || 0;
 
   const unlockedDepositsObj = useMemo(
     () =>
@@ -41,12 +41,12 @@ const ClaimPerToken = ({ bounty, tokenAddress, claimant, type, changeObj }) => {
   );
   const [unlockedDepositsValues] = useGetTokenValues(unlockedDepositsObj);
   const unlockedDepositVolume = formatVolume(unlockedDepositsObj?.volume || 0);
-  const unlockedDepositValue = unlockedDepositsValues?.total;
+  const unlockedDepositValue = unlockedDepositsValues?.total || 0;
 
   const claimedBalancesObj = useMemo(() => filterAndAggregate(bounty.payouts), [bounty]);
   const [balanceValuesclaimedBalances] = useGetTokenValues(claimedBalancesObj);
   const claimedVolume = formatVolume(claimedBalancesObj?.volume || 0);
-  const claimedBalances = balanceValuesclaimedBalances?.total;
+  const claimedBalances = balanceValuesclaimedBalances?.total || 0;
 
   const refundableVolume = () => {
     const refundable =
@@ -61,17 +61,17 @@ const ClaimPerToken = ({ bounty, tokenAddress, claimant, type, changeObj }) => {
 
   const stillClaimableObj = useMemo(() => filterAndAggregate(bounty.bountyTokenBalances), [tokenAddress]);
   const [stillClaimableValues] = useGetTokenValues(stillClaimableObj);
-  const stillClaimable = stillClaimableValues?.total ? stillClaimableValues?.total : 0;
+  const stillClaimable = stillClaimableValues?.total || 0;
 
   const refundedObj = useMemo(() => filterAndAggregate(bounty.refunds), [tokenAddress]);
   const [refundedValues] = useGetTokenValues(refundedObj);
   const refundVolume = formatVolume(refundedObj?.volume || 0);
-  const refundedValue = refundedValues?.total ? refundedValues?.total : 0;
+  const refundedValue = refundedValues?.total || 0;
 
   const balanceObjDeposits = useMemo(() => filterAndAggregate(bounty.deposits), [bounty]);
   const [balanceValuesDeposits] = useGetTokenValues(balanceObjDeposits);
   const totalDepositVolume = formatVolume(balanceObjDeposits?.volume || 0);
-  const totalDepositValue = balanceValuesDeposits?.total ? balanceValuesDeposits?.total : 0;
+  const totalDepositValue = balanceValuesDeposits?.total || 0;
 
   const currentDepositVolume = totalDepositVolume - refundVolume;
 

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -14,7 +14,6 @@ import { ThreeBarsIcon } from '@primer/octicons-react';
 import LinkDropdown from '../Utils/LinkDropdown';
 import { useRouter } from 'next/router';
 import NavLinks from './NavLinks';
-import ContractWizard from '../ContractWizard/ContractWizard';
 import LoadingBar from '../Loading/LoadingBar';
 import LoadingThread from '../Loading/LoadingThread.js';
 
@@ -27,7 +26,6 @@ const Navigation = () => {
   const [quickSearch, setQuickSearch] = useState('');
   const [items, setItems] = useState([]);
   const [searchable, setSearchable] = useState();
-  const [showWizard, setShowWizard] = useState(false);
   const [loadingBar, setLoadingBar] = useState(false);
   const [changeText, setChangeText] = useState(false);
   const { bountyMinted, authService, openQSubgraphClient, openQPrismaClient, utils, githubRepository, tokenClient } =
@@ -181,12 +179,6 @@ const Navigation = () => {
                 {quickSearch && <LinkDropdown items={items} />}
               </div>
               <NavLinks />
-              <button onClick={() => setShowWizard(true)}>
-                <div className='mx-2 text-[0.8rem] tracking-wider md:hover:text-primary text-muted font-bold hover:cursor-pointer'>
-                  Contract Wizard
-                </div>
-              </button>
-              {showWizard && <ContractWizard wizardVisibility={setShowWizard} />}
             </div>
           </div>
           <div className='flex items-center text-[0.8rem] lg:text-[1rem]'>
@@ -212,15 +204,7 @@ const Navigation = () => {
               ></input>
               {quickSearch && <LinkDropdown items={items} />}
             </div>
-
             <NavLinks />
-
-            <button onClick={() => setShowWizard(true)}>
-              <div className='flex text-[0.8rem] pt-1 border-t border-gray-700 tracking-wider text-nav-text font-bold'>
-                Contract Wizard
-              </div>
-            </button>
-            {showWizard && <ContractWizard wizardVisibility={setShowWizard} />}
           </div>
         </div>
       ) : null}

--- a/components/RefundBounty/ApproveTransferModal.js
+++ b/components/RefundBounty/ApproveTransferModal.js
@@ -68,7 +68,7 @@ const ApproveTransferModal = ({
   };
   return (
     <div>
-      <div className='justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 pl-20 outline-none focus:outline-none'>
+      <div className='justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none'>
         <div ref={modal} className='w-1/4 min-w-[320px]'>
           <div className='border-0 rounded-sm p-7 shadow-lg flex flex-col w-full bg-dark-mode outline-none focus:outline-none'>
             <div className='flex items-center justify-center border-solid'>


### PR DESCRIPTION
closes #803 => centering modal for extend deposit
closes #805 => showing TVL rather than budget when TVL = budget
closes #802 => making sure ClaimOverview columns are aligned on mobile
fixing a rest part of #777 (NaN values cleanup)

Centered modal
![image](https://user-images.githubusercontent.com/75732239/194007542-5c75652a-7181-4e94-a322-e8dfa82b497f.png)

TVL = Budget: shows TVL on BountyCardLean
![image](https://user-images.githubusercontent.com/75732239/194007382-d1d779b5-a041-4898-a46a-72341dc8f39b.png)
![image](https://user-images.githubusercontent.com/75732239/194007445-1c39b84b-95d0-4637-a60c-20c431174751.png)

ClaimOverview columns are aligned
![image](https://user-images.githubusercontent.com/75732239/194007134-2238e70b-508f-4130-8655-29ffcadac321.png)

Fixes NaN issue when amounts very small on ClaimOVerview:
![image](https://user-images.githubusercontent.com/75732239/194027003-c6769a4b-5cbd-4d48-a0c0-58b63cf6845a.png)

