### PR TITLE
fix: updated bounties to contracts in organisation card

### DIFF
--- a/components/Organization/HorizontalOrganizationCard.js
+++ b/components/Organization/HorizontalOrganizationCard.js
@@ -62,7 +62,7 @@ const HorizontalOrganizationCard = ({ organization }) => {
             {organization.starringUserIds?.length !== 1 && 's'}
           </div>
           <div className='mt-1 text text-sm leading-normal text-muted truncate'>
-            {orgBounties.length} {orgBounties.length !== 1 ? 'bounties' : 'bounty'}
+            {orgBounties.length} {orgBounties.length !== 1 ? 'contracts' : 'contract'}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Very simple change. Closes #878 ! 

If changing nomenclature on organisations, I'd suggest renaming to contracts everywhere instead of bounties. 

Stylistic note: Also, why not use Atoms? Plus, curious if you've looked into Github's Primer Design System. Aware interfacing w. Tailwind could be tricky but it might be interesting given OpenQ's design is so similar!