### PR TITLE
Decimal input + Volume fix on fixed contest contracts + Priority 3 issues

### DIFF
--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -8,6 +8,7 @@ import StoreContext from '../../store/Store/StoreContext';
 import TokenBalances from '../TokenBalances/TokenBalances';
 import useGetTokenValues from '../../hooks/useGetTokenValues';
 import PieChart from './PieChart';
+import { ethers } from 'ethers';
 
 const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
   const [appState] = useContext(StoreContext);
@@ -22,6 +23,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
   };
   const payoutBalances = useMemo(() => createPayout(bounty), [bounty]);
   const [payoutValues] = useGetTokenValues(payoutBalances);
+
   let type = 'Fixed Price';
 
   switch (bounty.bountyType) {
@@ -37,6 +39,14 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
     case '3':
       type = 'Fixed Contest';
       break;
+  }
+
+  function formatVolume(tierVolume) {
+    const tokenMetadata = appState.tokenClient.getToken(bounty.payoutTokenAddress);
+    let bigNumberVolume = ethers.BigNumber.from(tierVolume.toString());
+    let decimals = parseInt(tokenMetadata.decimals) || 18;
+    let formattedVolume = ethers.utils.formatUnits(bigNumberVolume, decimals);
+    return formattedVolume;
   }
 
   return (
@@ -113,7 +123,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
           </li>
           <PieChart payoutSchedule={bounty.payoutSchedule} />
         </>
-      ) : bounty.bountyType === '2' || bounty.bountyType === '3' ? (
+      ) : bounty.bountyType == 3 ? (
         <li className='border-b border-web-gray py-3'>
           <div className='text-xs font-semibold text-muted'>Current Payout Schedule</div>
           <div className='flex items-center gap-4 pt-2 text-primary'>
@@ -129,7 +139,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
                     index + 1
                   )} winner:`}</div>
                   <div className='text-xs font-semibold'>
-                    {t} {token.symbol}
+                    {formatVolume(t)} {token.symbol}
                   </div>
                 </div>
               );

--- a/components/MintBounty/SetTierValues.js
+++ b/components/MintBounty/SetTierValues.js
@@ -34,15 +34,16 @@ const SetTierValues = ({
     setFixedTierVolumes(newFixedVolumes);
   }, [tierArr]);
   function onFixedTierChange(e, localTierVolumes) {
-    if (
-      parseInt(e.target.value) >= 0 ||
-      parseInt(e.target.value) === '' ||
-      !Number(e.target.value) ||
-      parseInt(e.target.value) > 100
-    ) {
+    if (!isNaN(e.target.value) && parseFloat(e.target.value) >= 0) {
       setFixedTierVolumes({
         ...localTierVolumes,
-        [e.name]: parseInt(e.target.value),
+        [e.name]: e.target.value,
+      });
+    }
+    if (e.target.value === '') {
+      setFixedTierVolumes({
+        ...localTierVolumes,
+        [e.name]: 0,
       });
     }
   }

--- a/components/MintBounty/TextTierInput.js
+++ b/components/MintBounty/TextTierInput.js
@@ -11,7 +11,7 @@ const TextTierInput = ({ tier, tierVolumes, onTierVolumeChange, style }) => {
   }, []);
 
   const handleChange = (value, tierVolumes) => {
-    const passedValue = parseInt(value) || 0;
+    const passedValue = value;
     onTierVolumeChange(
       {
         name: tier,

--- a/components/Submissions/WinnerSelect.js
+++ b/components/Submissions/WinnerSelect.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState, useMemo } from 'react';
 import useWeb3 from '../../hooks/useWeb3';
 import StoreContext from '../../store/Store/StoreContext';
 import LoadingIcon from '../Loading/ButtonLoadingIcon';
@@ -6,6 +6,7 @@ import { RESTING, CONFIRM, TRANSFERRING, SUCCESS, ERROR } from '../FundBounty/Ap
 import ToolTip from '../Utils/ToolTipNew';
 import ModalDefault from '../Utils/ModalDefault';
 import { ethers } from 'ethers';
+import useGetTokenValues from '../../hooks/useGetTokenValues';
 
 const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr }) => {
   const [showModal, setShowModal] = useState();
@@ -18,6 +19,19 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr }) => 
   const [closer, setCloser] = useState('');
   const [error, setError] = useState({});
   const zeroAddress = '0x0000000000000000000000000000000000000000';
+  const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances);
+  const price = tokenValues?.total;
+  const createFixedPayout = () => {
+    return prize.payout && bounty.bountyType == 3
+      ? {
+          tokenAddress: bounty.payoutTokenAddress,
+          volume: prize.payout,
+        }
+      : null;
+  };
+  const payoutBalances = useMemo(() => createFixedPayout(), [prize]);
+  const [fixedPayoutValue] = useGetTokenValues(payoutBalances);
+
   let unit;
   useEffect(() => {
     const getAddress = async () => {
@@ -78,6 +92,15 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr }) => 
     setSelectionState(CONFIRM);
     setShowModal();
   };
+
+  function formatVolume(fixedPayout) {
+    const tokenMetadata = appState.tokenClient.getToken(bounty.payoutTokenAddress);
+    let bigNumberVolume = ethers.BigNumber.from(fixedPayout.toString());
+    let decimals = parseInt(tokenMetadata.decimals) || 18;
+    let formattedVolume = ethers.utils.formatUnits(bigNumberVolume, decimals);
+    return formattedVolume;
+  }
+
   const goBackBtn = {
     CONFIRM: (
       <button className=' btn-danger' onClick={resetState}>
@@ -93,7 +116,7 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr }) => 
         innerStyles={'  whitespace-pre-wrap'}
         relativePosition={'-right-4 w-32 md:right:auto md:w-60'}
         hideToolTip={closer}
-        toolTipText='User has not registered their Github account on OpenQ with a wallet address, please have them register a wallet address before paying out.'
+        toolTipText='Winner needs to register their Github account on OpenQ with a wallet address before paying out.'
       >
         <button
           disabled={!closer}
@@ -166,11 +189,23 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr }) => 
                 </a>{' '}
                 challenge.
               </p>
-              <p className='my-2'>
-                This will automaticaly send {prize.payout}
-                {bounty.bountyType === '2' ? '% of funds' : unit} staked on this competition to the author of this
-                submission.
-              </p>
+              {closer && closer != zeroAddress ? (
+                <p className='my-2'>
+                  This will automaticaly send{' '}
+                  {bounty.bountyType === '2' ? prize.payout + '% of funds' : formatVolume(prize.payout) + unit} staked
+                  on this competition (
+                  {bounty.bountyType === '2'
+                    ? appState.utils.formatter.format((price * prize.payout) / 100)
+                    : appState.utils.formatter.format(fixedPayoutValue?.total)}
+                  ) to the author of this submission, at the following address:{' '}
+                  {`${closer.slice(0, 4)}...${closer.slice(39)}`} .
+                </p>
+              ) : (
+                <p className='my-2'>
+                  However, the user has not registered their Github account on OpenQ with a wallet address, please have
+                  them register a wallet address before paying out.
+                </p>
+              )}
             </>
           )}
           {selectionState === TRANSFERRING && (

--- a/components/Utils/TweetAbout.js
+++ b/components/Utils/TweetAbout.js
@@ -8,7 +8,6 @@ const TweetAbout = ({ tweetText, bounty }) => {
       href={`https://twitter.com/intent/tweet/?text=${tweetText}${process.env.NEXT_PUBLIC_BASE_URL}/contract/${bounty.bountyId}/${bounty.bountyAddress}`}
       target='_blank'
       rel='noopener noreferrer'
-      legacyBehavior
     >
       <div className='flex justify-center items-center btn-primary'>
         <div className='flex justify-center items-center gap-2'>

--- a/services/ethers/OpenQClient.js
+++ b/services/ethers/OpenQClient.js
@@ -122,9 +122,18 @@ class OpenQClient {
           break;
         case 'Fixed Contest':
           {
+            const tierVolumes = data.tiers.map((tier) => {
+              const payoutVolumeInWei = tier * 10 ** data.payoutToken.decimals;
+              const payoutBigNumberVolumeInWei = ethers.BigNumber.from(
+                payoutVolumeInWei.toLocaleString('fullwide', {
+                  useGrouping: false,
+                })
+              );
+              return payoutBigNumberVolumeInWei;
+            });
             const tieredAbiEncodedParams = abiCoder.encode(
               ['uint256[]', 'address'],
-              [data.tiers, data.payoutToken.address]
+              [tierVolumes, data.payoutToken.address]
             );
             bountyInitOperation = [3, tieredAbiEncodedParams];
           }


### PR DESCRIPTION
closes #939:
- Now decimal values can be input into the fixed contest contracts
- Also corrected the input values to the smart contract, which needed to be transformed through tokenMetadata (were passed on as such, like for the percentages, rendering very small values in tokens)
- adapted the BountyMetadata volumes for tiers on fixed contests accordingly

closes #937 => removed legacyBehavior from Link to allow it to function properly

closes #950: 
- modified the text when user not registered with Eth address
- added value and address of closer, and dealing with zeroAddress for contest contracts
- also formatted volume, added value and address of closer for fixed contest contracts

![image](https://user-images.githubusercontent.com/75732239/201139132-e2cfb049-076f-4323-b83c-a2cea3f70410.png)
![image](https://user-images.githubusercontent.com/75732239/201139289-617cd48b-ba60-4616-885e-73e13822e508.png)
![image](https://user-images.githubusercontent.com/75732239/201139363-5cbfa1b0-1a67-4ab7-b584-69b33c83a7f6.png)
