### PR TITLE
Handles payout schedules and budget on fixed price contracts, Mobile UI improvements.

### DIFF
--- a/__tests__/MintBounty/MintBountyModal.test.js
+++ b/__tests__/MintBounty/MintBountyModal.test.js
@@ -86,7 +86,7 @@ const test = (issue, type) => {
     });
   });
 
-  if (type !== '3') {
+  if (type[0] !== '3') {
     it(`should handle extra data for type ${type[0]}`, async () => {
       // ARRANGE
       const user = userEvent.setup();

--- a/__tests__/MintBounty/MintBountyModal.test.js
+++ b/__tests__/MintBounty/MintBountyModal.test.js
@@ -86,51 +86,53 @@ const test = (issue, type) => {
     });
   });
 
-  it(`should handle extra data for type ${type[0]}`, async () => {
-    // ARRANGE
-    const user = userEvent.setup();
-    render(<MintBountyModal types={type} />);
-    // ACT
-    const inputs = await screen.findAllByRole('textbox');
-    await user.type(inputs[0], issue.url);
-    await user.click(screen.getByRole('checkbox'));
-    await user.type(screen.getByLabelText('budget'), '123assdf');
-    await waitFor(async () => {
-      expect(screen.getByLabelText('budget').value).toBe('123');
+  if (type !== '3') {
+    it(`should handle extra data for type ${type[0]}`, async () => {
+      // ARRANGE
+      const user = userEvent.setup();
+      render(<MintBountyModal types={type} />);
+      // ACT
+      const inputs = await screen.findAllByRole('textbox');
+      await user.type(inputs[0], issue.url);
+      await user.click(screen.getByRole('checkbox'));
+      await user.type(screen.getByLabelText('budget'), '123assdf');
+      await waitFor(async () => {
+        expect(screen.getByLabelText('budget').value).toBe('123');
 
-      // ASSERT
-      switch (type[0]) {
-        case '1':
-          {
-            await user.type(screen.getByLabelText('split'), '123assdf');
-            expect(screen.getByLabelText('split').value).toBe('123');
-          }
-          break;
+        // ASSERT
+        switch (type[0]) {
+          case '1':
+            {
+              await user.type(screen.getByLabelText('split'), '123assdf');
+              expect(screen.getByLabelText('split').value).toBe('123');
+            }
+            break;
 
-        case '2':
-          {
-            expect(screen.getAllByText(/place winner/)).toHaveLength(3);
-            await user.type(screen.getByLabelText(/tier/), '2');
-            expect(screen.getAllByText(/place winner/)).toHaveLength(32);
+          case '2':
+            {
+              expect(screen.getAllByText(/place winner/)).toHaveLength(3);
+              await user.type(screen.getByLabelText(/tier/), '2');
+              expect(screen.getAllByText(/place winner/)).toHaveLength(32);
 
-            /**/
-          }
-          break;
+              /**/
+            }
+            break;
 
-        case '3':
-          expect(screen.getAllByText(/fixed Contest/i)).toHaveLength(4);
+          case '3':
+            expect(screen.getAllByText(/fixed Contest/i)).toHaveLength(4);
 
-          break;
-        default:
-      }
+            break;
+          default:
+        }
 
-      const deploy = screen.getAllByText(/deploy/i);
-      expect(deploy[0]).toBeInTheDocument();
-      // should not have null or undefined values
-      const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
-      expect(nullish).toHaveLength(0);
+        const deploy = screen.getAllByText(/deploy/i);
+        expect(deploy[0]).toBeInTheDocument();
+        // should not have null or undefined values
+        const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
+        expect(nullish).toHaveLength(0);
+      });
     });
-  });
+  }
 };
 describe('MintBountyModal', () => {
   issues.forEach((issue) => {

--- a/__tests__/MintBounty/SetTierValues.test.js
+++ b/__tests__/MintBounty/SetTierValues.test.js
@@ -25,6 +25,7 @@ describe('SetTier', () => {
       <SetTierValues
         category={'Contest'}
         sum={9}
+        currentSum={9}
         setSum={mockSum}
         setEnableContest={mockEnabler}
         finalTierVolumes={['2', '3', '4']}

--- a/__tests__/MintBounty/SetTierValues.test.js
+++ b/__tests__/MintBounty/SetTierValues.test.js
@@ -93,6 +93,7 @@ it('should give choice for bar inputs or number inputs', async () => {
     <SetTierValues
       category={'Contest'}
       sum={9}
+      currentSum={9}
       setSum={mockSum}
       setEnableContest={mockEnabler}
       finalTierVolumes={['2', '3', '4']}

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -194,12 +194,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
       }
 
       if (bounty.bountyType === '3') {
-        transaction = await openQClient.setPayoutScheduleFixed(
-          library,
-          bounty.bountyId,
-          finalTierVolumes,
-          payoutToken.address
-        );
+        transaction = await openQClient.setPayoutScheduleFixed(library, bounty.bountyId, finalTierVolumes, payoutToken);
       }
       refreshBounty();
       setModal({

--- a/components/Bounty/BountyHeading.js
+++ b/components/Bounty/BountyHeading.js
@@ -15,7 +15,7 @@ const BountyHeading = ({ bounty, price, budget }) => {
   const [payoutPrice] = useGetTokenValues(bounty.payouts);
   const marker = appState.utils.getBountyMarker(bounty, authState.login);
   const getPayoutScheduleBalance = (bounty) => {
-    if (bounty.bountyType === '3') {
+    if (bounty.bountyType === '3' && bounty.payoutSchedule) {
       const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });

--- a/components/Bounty/BountyHeading.js
+++ b/components/Bounty/BountyHeading.js
@@ -32,7 +32,7 @@ const BountyHeading = ({ bounty, price, budget }) => {
     <div className='sm:px-8 px-4 w-full max-w-[1200px] pb-2'>
       <div className='pt-6 pb-2 w-full flex flex-wrap'>
         <h1 className='sm:text-[32px] text-xl flex-1 leading-tight min-w-[240px] pr-20'>
-          <span className='text-primary'>{bounty.title}asdf </span>
+          <span className='text-primary'>{bounty.title} </span>
           {bounty.url ? (
             <Link href={bounty.url} rel='noopener norefferer' target='_blank' legacyBehavior>
               <span className='text-link-colour cursor-pointer font-light hover:underline'>#{bounty.number}</span>

--- a/components/Bounty/BountyHeading.js
+++ b/components/Bounty/BountyHeading.js
@@ -16,7 +16,7 @@ const BountyHeading = ({ bounty, price, budget }) => {
   const marker = appState.utils.getBountyMarker(bounty, authState.login);
   const getPayoutScheduleBalance = (bounty) => {
     if (bounty.bountyType === '3') {
-      const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+      const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });
       return {

--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -25,7 +25,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
   const [payoutValues] = useGetTokenValues(payoutBalances);
 
   const getPayoutScheduleBalance = (bounty) => {
-    if (bounty.bountyType === '3') {
+    if (bounty.bountyType === '3' && bounty.payoutSchedule) {
       const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });

--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -26,7 +26,7 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
 
   const getPayoutScheduleBalance = (bounty) => {
     if (bounty.bountyType === '3') {
-      const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+      const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });
       return {

--- a/components/Bounty/BountyMetadata.js
+++ b/components/Bounty/BountyMetadata.js
@@ -24,6 +24,21 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
   const payoutBalances = useMemo(() => createPayout(bounty), [bounty]);
   const [payoutValues] = useGetTokenValues(payoutBalances);
 
+  const getPayoutScheduleBalance = (bounty) => {
+    if (bounty.bountyType === '3') {
+      const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+        return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
+      });
+      return {
+        volume: totalPayoutsScheduled.toString(),
+        tokenAddress: bounty.payoutTokenAddress,
+      };
+    }
+  };
+
+  const payoutScheduledBalance = useMemo(() => getPayoutScheduleBalance(bounty), [bounty]);
+  const [payoutScheduledValues] = useGetTokenValues(payoutScheduledBalance);
+
   let type = 'Fixed Price';
 
   switch (bounty.bountyType) {
@@ -74,11 +89,13 @@ const BountyMetadata = ({ bounty, setInternalMenu, price, budget, split }) => {
         </li>
       )}
 
-      {bounty.fundingGoalVolume && (
+      {(bounty.fundingGoalVolume || payoutScheduledValues?.total) && (
         <li className='border-b border-web-gray py-3'>
           <div className='text-xs font-semibold text-muted'>🎯 Current Target Budget</div>
           <div className='text-xs font-semibold text-primary pt-2'>
-            {(budget && appState.utils.formatter.format(budget)) || '$0.00'}
+            {((budget || payoutScheduledValues?.total) &&
+              appState.utils.formatter.format(payoutScheduledValues?.total || budget)) ||
+              '$0.00'}
           </div>
         </li>
       )}

--- a/components/Bounty/CarouselBounty.js
+++ b/components/Bounty/CarouselBounty.js
@@ -29,7 +29,7 @@ const CarouselBounty = ({ bounty }) => {
   const price = tokenValues?.total;
 
   const getPayoutScheduleBalance = (bounty) => {
-    if (bounty.bountyType === '3') {
+    if (bounty.bountyType === '3' && bounty.payoutSchedule) {
       const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });

--- a/components/Bounty/CarouselBounty.js
+++ b/components/Bounty/CarouselBounty.js
@@ -30,7 +30,7 @@ const CarouselBounty = ({ bounty }) => {
 
   const getPayoutScheduleBalance = (bounty) => {
     if (bounty.bountyType === '3') {
-      const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+      const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });
       return {

--- a/components/Bounty/CarouselBounty.js
+++ b/components/Bounty/CarouselBounty.js
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { PersonAddIcon, PersonIcon, PeopleIcon } from '@primer/octicons-react';
 import LabelsList from '../Bounty/LabelsList';
 import useWeb3 from '../../hooks/useWeb3';
+import { ethers } from 'ethers';
 
 const CarouselBounty = ({ bounty }) => {
   const [appState] = useContext(StoreContext);
@@ -26,6 +27,21 @@ const CarouselBounty = ({ bounty }) => {
   const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances);
   const [payoutValues] = useGetTokenValues(bounty?.payouts);
   const price = tokenValues?.total;
+
+  const getPayoutScheduleBalance = (bounty) => {
+    if (bounty.bountyType === '3') {
+      const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+        return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
+      });
+      return {
+        volume: totalPayoutsScheduled.toString(),
+        tokenAddress: bounty.payoutTokenAddress,
+      };
+    }
+  };
+
+  const payoutScheduledBalance = useMemo(() => getPayoutScheduleBalance(bounty), [bounty]);
+  const [payoutScheduledValues] = useGetTokenValues(payoutScheduledBalance);
 
   return (
     <div className='border-web-gray bg-dark-mode p-4 gap-2 border rounded-sm flex mb-1'>
@@ -120,7 +136,7 @@ const CarouselBounty = ({ bounty }) => {
                         </>
                       )}
                     </div>
-                  ) : budget > 0 ? (
+                  ) : budget > 0 || payoutScheduledValues?.total > 0 ? (
                     <>
                       <div className='flex flex-row space-x-1 items-center'>
                         <div className='pr-2 pt-1'>
@@ -129,7 +145,9 @@ const CarouselBounty = ({ bounty }) => {
 
                         <>
                           <div className='font-semibold '>Budget</div>
-                          <div className=''>{appState.utils.formatter.format(budget)}</div>
+                          <div className=''>
+                            {appState.utils.formatter.format(payoutScheduledValues?.total || budget)}
+                          </div>
                         </>
                       </div>
                     </>

--- a/components/Bounty/TotalValue.js
+++ b/components/Bounty/TotalValue.js
@@ -6,6 +6,7 @@ import StoreContext from '../../store/Store/StoreContext';
 const TotalValue = ({ price, bounty }) => {
   const [appState] = useContext(StoreContext);
   const [payoutPrice] = useGetTokenValues(bounty.payouts);
+
   return (
     <div className='text-base font-semibold text-primary'>
       {bounty.status !== '0' ? (

--- a/components/BountyCard/BountyCardLean.js
+++ b/components/BountyCard/BountyCardLean.js
@@ -7,6 +7,7 @@ import useGetTokenValues from '../../hooks/useGetTokenValues';
 import ToolTipNew from '../Utils/ToolTipNew';
 import { PersonAddIcon, PersonIcon, PeopleIcon } from '@primer/octicons-react';
 import ReactGA from 'react-ga4';
+import { ethers } from 'ethers';
 
 // Custom
 import StoreContext from '../../store/Store/StoreContext';
@@ -20,6 +21,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
   const [isModal, setIsModal] = useState();
   const [hovered, setHovered] = useState();
   const [payoutPrice] = useGetTokenValues(bounty?.payout);
+
   const currentDate = Date.now();
   const relativeDeployDay = parseInt((currentDate - bounty?.bountyMintTime * 1000) / 86400000);
   const createTokenBalances = (bounty) => {
@@ -27,7 +29,20 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
   };
   const tokenBalances = useMemo(() => createTokenBalances(bounty), [bounty.tokenBalances]);
   const [tokenValues] = useGetTokenValues(tokenBalances);
+  const getPayoutScheduleBalance = (bounty) => {
+    if (bounty.bountyType === '3') {
+      const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+        return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
+      });
+      return {
+        volume: totalPayoutsScheduled.toString(),
+        tokenAddress: bounty.payoutTokenAddress,
+      };
+    }
+  };
 
+  const payoutScheduledBalance = useMemo(() => getPayoutScheduleBalance(bounty), [bounty]);
+  const [payoutScheduledValues] = useGetTokenValues(payoutScheduledBalance);
   const createBudget = (bounty) => {
     return bounty.fundingGoalTokenAddress
       ? {
@@ -218,6 +233,17 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
 
                       <div className='font-semibold '>Budget</div>
                       <div className=''>{appState.utils.formatter.format(budget)}</div>
+                    </div>
+                  </>
+                ) : payoutScheduledValues?.total ? (
+                  <>
+                    <div className='flex flex-row space-x-1 w-min items-center'>
+                      <div className='pr-2 w-4 pt-1'>
+                        <Image src='/crypto-logos/ETH.svg' alt='avatarUrl' width='12' height='20' />
+                      </div>
+
+                      <div className='font-semibold '>Budget</div>
+                      <div className=''>{appState.utils.formatter.format(payoutScheduledValues?.total)}</div>
                     </div>
                   </>
                 ) : (

--- a/components/BountyCard/BountyCardLean.js
+++ b/components/BountyCard/BountyCardLean.js
@@ -31,7 +31,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
   const [tokenValues] = useGetTokenValues(tokenBalances);
   const getPayoutScheduleBalance = (bounty) => {
     if (bounty.bountyType === '3') {
-      const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+      const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });
       return {

--- a/components/BountyCard/BountyCardLean.js
+++ b/components/BountyCard/BountyCardLean.js
@@ -30,7 +30,7 @@ const BountyCardLean = ({ bounty, loading, index, length, unWatchable }) => {
   const tokenBalances = useMemo(() => createTokenBalances(bounty), [bounty.tokenBalances]);
   const [tokenValues] = useGetTokenValues(tokenBalances);
   const getPayoutScheduleBalance = (bounty) => {
-    if (bounty.bountyType === '3') {
+    if (bounty.bountyType === '3' && bounty.payoutSchedule) {
       const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
         return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
       });

--- a/components/Layout/Footer.js
+++ b/components/Layout/Footer.js
@@ -33,7 +33,7 @@ const Footer = () => {
   }, [open]);
   return (
     <div className='flex justify-center justify-items-center full'>
-      <div className='text-primary max-w- text-sm px-4 lg:px-20 max-w-[1120px] lg:py-12 py-4  grid gap-x-4 lg:grid-cols-[0.5fr_1fr_1fr_1.5fr] grid-cols-[1fr_1fr]  lg:grid-rows-2 grid-rows-4 lg:grid-flow-col items-center lg:flex-row w-full justify-between content-center font-semibold grid-flow-row'>
+      <div className='text-primary max-w- text-sm px-4 lg:px-20 max-w-[1120px] lg:py-12 py-4  xs:grid flex flex-col content-start items-start gap-4 xs:gap-y-0 lg:grid-cols-[0.5fr_1fr_1fr_1.5fr] grid-cols-[1fr_1fr]  lg:grid-rows-2 grid-rows-4 lg:grid-flow-col xs:items-center lg:flex-row w-full justify-between xs:content-center font-semibold grid-flow-row'>
         <div className='font-semibold font-sans text-3xl'>OpenQ</div>
         <OpenQSocials />
         <Link href={'https://openq.canny.io/openq-feature-requests'} className='text-lg lg:justify-self-center '>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -49,6 +49,7 @@ const MintBountyModal = ({ modalVisibility, types }) => {
   const [tier, setTier] = useState(3);
   const [tierArr, setTierArr] = useState(['0', '1', '2']);
   const [tierVolumes, setTierVolumes] = useState({ 0: 1, 1: 1, 2: 1 });
+  const [currentSum, setCurrentSum] = useState(0);
 
   const [finalTierVolumes, setFinalTierVolumes] = useState([1, 1, 1]);
   const [payoutVolume, setPayoutVolume] = useState('');
@@ -305,6 +306,22 @@ const MintBountyModal = ({ modalVisibility, types }) => {
     if (finalTierVolumes.length) {
       setSum(finalTierVolumes.reduce((a, b) => a + b));
     }
+    if (finalTierVolumes.length) {
+      setCurrentSum(
+        finalTierVolumes.reduce((a, b) => {
+          if (a && b) {
+            return a + b;
+          }
+          if (a) {
+            return a;
+          }
+          if (b) {
+            return b;
+          }
+          return 0;
+        })
+      );
+    }
     if (sum == 100) {
       setEnableContest(true);
     }
@@ -334,7 +351,9 @@ const MintBountyModal = ({ modalVisibility, types }) => {
 
   const btn = !error && (
     <ToolTipNew
-      outerStyles={''}
+      groupStyles={''}
+      outerStyles={'hover:hidden -top-20 md:top-auto'}
+      triangleStyles={'mt-7 md:mt-1 rotate-180 md:rotate-0 '}
       hideToolTip={
         (enableContest &&
           enableMint &&
@@ -349,6 +368,8 @@ const MintBountyModal = ({ modalVisibility, types }) => {
           ? 'Issue closed'
           : account && isOnCorrectNetwork && (!enableMint || !issue?.url.includes('/issues/'))
           ? 'Please choose an elgible issue.'
+          : currentSum !== sum
+          ? 'Please make sure each tier gets a percentage.'
           : !enableContest
           ? 'Please make sure the sum of tier percentages adds up to 100.'
           : isOnCorrectNetwork
@@ -574,6 +595,7 @@ const MintBountyModal = ({ modalVisibility, types }) => {
                     <SetTierValues
                       category={category}
                       sum={sum}
+                      currentSum={currentSum}
                       finalTierVolumes={finalTierVolumes}
                       setFinalTierVolumes={setFinalTierVolumes}
                       setSum={setSum}

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -462,39 +462,40 @@ const MintBountyModal = ({ modalVisibility, types }) => {
                 </div>
               </div>
 
-              <div className=' flex flex-col gap-2 w-full py-2 items-start text-base bg-[#161B22]'>
-                <div className='flex items-center gap-2'>
-                  Set a Budget
-                  <input type='checkbox' className='checkbox' onChange={() => setBudgetInput(!budgetInput)}></input>
-                  <ToolTipNew
-                    mobileX={10}
-                    toolTipText={
-                      category === 'Fixed Price'
-                        ? 'Amount of funds you would like to escrow on this issue.'
-                        : 'How much will each successful submitter earn?'
-                    }
-                  >
-                    <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
-                      ?
-                    </div>
-                  </ToolTipNew>
-                </div>
-                <span className='text-sm '>
-                  You don{"'"}t have to deposit now! The budget is just what you intend to pay.
-                </span>
-                {budgetInput ? (
-                  <div className='flex-1 w-full px-2'>
-                    <TokenFundBox
-                      label='budget'
-                      onCurrencySelect={onGoalCurrencySelect}
-                      onVolumeChange={handleGoalChange}
-                      volume={goalVolume}
-                      token={goalToken}
-                    />
+              {category !== 'Fixed Contest' && (
+                <div className=' flex flex-col gap-2 w-full py-2 items-start text-base bg-[#161B22]'>
+                  <div className='flex items-center gap-2'>
+                    Set a Budget
+                    <input type='checkbox' className='checkbox' onChange={() => setBudgetInput(!budgetInput)}></input>
+                    <ToolTipNew
+                      mobileX={10}
+                      toolTipText={
+                        category === 'Fixed Price'
+                          ? 'Amount of funds you would like to escrow on this issue.'
+                          : 'How much will each successful submitter earn?'
+                      }
+                    >
+                      <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
+                        ?
+                      </div>
+                    </ToolTipNew>
                   </div>
-                ) : null}
-              </div>
-
+                  <span className='text-sm '>
+                    You don{"'"}t have to deposit now! The budget is just what you intend to pay.
+                  </span>
+                  {budgetInput ? (
+                    <div className='flex-1 w-full px-2'>
+                      <TokenFundBox
+                        label='budget'
+                        onCurrencySelect={onGoalCurrencySelect}
+                        onVolumeChange={handleGoalChange}
+                        volume={goalVolume}
+                        token={goalToken}
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              )}
               {category === 'Split Price' ? (
                 <>
                   <div className='flex flex-col gap-2 w-full items-start py-2 pb-4 text-base bg-[#161B22]'>

--- a/components/MintBounty/SetTierValues.js
+++ b/components/MintBounty/SetTierValues.js
@@ -14,6 +14,7 @@ const SetTierValues = ({
   finalTierVolumes,
   setFinalTierVolumes,
   initialVolumes,
+  currentSum,
 }) => {
   const newFixedVolumes = {};
   const newVolumesArr = [];
@@ -118,12 +119,16 @@ const SetTierValues = ({
             toggleFunc={handleToggle}
             names={['Visual', 'Text']}
           />
-          {sum > 100 ? (
+          {sum !== currentSum ? (
+            <span className='text-sm'>You must give a value for each tier</span>
+          ) : sum > 100 ? (
             <span className='text-sm  text-[#f85149]'>The sum can not be more than 100%!</span>
           ) : sum === 100 ? (
             <span className='text-sm '>Sum is 100, now you can mint.</span>
           ) : (
-            <span className='text-sm'>For the sum to add up to 100, you still need to allocate: {100 - sum} %</span>
+            <span className='text-sm'>
+              For the sum to add up to 100, you still need to allocate: {100 - currentSum} %
+            </span>
           )}
           {toggleVal === 'Visual' ? (
             <div className=' w-full mx-h-60 pl-4 overflow-y-auto overflow-x-hidden'>
@@ -146,7 +151,7 @@ const SetTierValues = ({
               })}
             </div>
           )}
-          <TierResult sum={sum} finalTierVolumes={finalTierVolumes} />
+          <TierResult sum={currentSum} finalTierVolumes={finalTierVolumes} />
         </div>
       ) : (
         <div className='max-h-40 w-full flex flex-col gap-2 overflow-y-auto overflow-x-hidden'>

--- a/components/MintBounty/TierInput.js
+++ b/components/MintBounty/TierInput.js
@@ -69,6 +69,7 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
         }
       };
       window.addEventListener('mouseup', handleDragEnd);
+      window.addEventListener('touchend', handleDragEnd);
 
       () => {
         edgeOfScale.current.removeEventListener('mousedown');
@@ -94,6 +95,8 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
       <div>{suffix} place winner</div>
       <div
         onMouseDown={handleDragBegin}
+        onTouchStart={handleDragBegin}
+        onTouchMove={handleMouseMove}
         onMouseMove={handleMouseMove}
         className={`flex w-11/12 text-sm content-center items-center gap-2 mb-1 ${style}`}
       >
@@ -115,7 +118,7 @@ const TierInput = ({ tier, onTierVolumeChange, style, tierVolumes }) => {
               onMouseMove={handleMouseMove}
               style={{ transform: `scaleX(${1 / reactScale})` }}
               type='textarea'
-              className='resize-x w-6 opacity-0  h-4 float-right relative left-3 cursor-ew-resize overflow-visible'
+              className='resize-x w-6 opacity-0 scale-150  h-4 float-right relative left-3 cursor-ew-resize overflow-visible'
             ></div>
           </div>
         </div>

--- a/components/Organization/HorizontalOrganizationCard.js
+++ b/components/Organization/HorizontalOrganizationCard.js
@@ -49,7 +49,7 @@ const HorizontalOrganizationCard = ({ organization }) => {
   };
   // Render
   return (
-    <div className='grid grid-cols-[64px_1fr_73px] gap-x-4 h-[118px] content-center mt-0 border-b border-web-gray py-6'>
+    <div className='grid grid-cols-[64px_1fr_73px] gap-x-2 sm:gap-x-4 h-[118px] content-center mt-0 border-b border-web-gray py-6'>
       <div className='rounded-sm self-center overflow-hidden h-16'>
         <Image src={organization.avatarUrl} width='64' height='64' />
       </div>
@@ -73,7 +73,7 @@ const HorizontalOrganizationCard = ({ organization }) => {
         <button
           onClick={handleStar}
           disabled={starredDisabled}
-          className='flex items-center text-xs bg-inactive-gray leading-5 h-7 px-3 py-[3px] hover:bg-active-gray rounded-sm border hover:border-border-active border-border-gray'
+          className='hidden xs:flex items-center text-xs  bg-inactive-gray leading-5 h-7 px-3 py-[3px] hover:bg-active-gray rounded-sm border hover:border-border-active border-border-gray'
         >
           <svg
             xmlns='http://www.w3.org/2000/svg'

--- a/components/ShowCase/ShowCasePage.js
+++ b/components/ShowCase/ShowCasePage.js
@@ -115,7 +115,7 @@ const ShowCasePage = ({ pr }) => {
       </div>
 
       <h3 className='flex gap-2 items-center'>
-        <span className='py-1 text-xl pt-8 text-primary'>Contributors</span>{' '}
+        <span className='py-1 text-xl pt-8 text-primary'>Contributor</span>{' '}
         {/*    {!showForm && isAuthor ? (
           <button onClick={openContributorForm}>
             <svg
@@ -189,8 +189,8 @@ const ShowCasePage = ({ pr }) => {
       )}
       <div className='py-2'>
         <div className='flex gap-2 h-6 text-primary'>
-          <Link href={pr.author.url} legacyBehavior>
-            <Image className='rounded-lg' src={pr.author.avatarUrl} height={'32px'} width={'32'} />
+          <Link href={pr.author.url}>
+            <Image className='rounded-lg h-8' src={pr.author.avatarUrl} height={'32px'} width={'32px'} />
           </Link>
           <div className='text-xl '>{pr.author.login}</div>
           <Link href={`https://twitter.com/${pr.author.twitterUsername}`} legacyBehavior>
@@ -208,14 +208,16 @@ const ShowCasePage = ({ pr }) => {
               <div className='text-xl '>{contributor.login}</div>
               {contributor.twitterUsername}
               {contributor.twitterUsername && (
-                <Link
-                  href={`https://twitter.com/${contributor.twitterUsername}`}
-                  target='_blank'
-                  rel='noopener norefferer'
-                  legacyBehavior
-                >
-                  <Image width={24} height={24} src={'/social-icons/twitter.svg'} />
-                </Link>
+                <div className='pt-1 cursor-pointer'>
+                  <Link
+                    href={`https://twitter.com/${contributor.twitterUsername}`}
+                    target='_blank'
+                    rel='noopener norefferer'
+                    legacyBehavior
+                  >
+                    <Image width={24} height={24} src={'/social-icons/twitter.svg'} />
+                  </Link>
+                </div>
               )}
               {isAuthor && (
                 <button className='mt-1' value={contributor.id} onClick={removeContributor}>

--- a/components/Submissions/SubmissionCard.js
+++ b/components/Submissions/SubmissionCard.js
@@ -13,7 +13,7 @@ const SubmissionCard = ({ pr, bounty, refreshBounty }) => {
 
   const linkedPrize = bounty.claims.filter((claim) => claim.claimantAsset === pr.url)[0];
   return (
-    <div className={`min-w-[300px] w-60  border rounded-sm border-border-gray bg-menu-bg`}>
+    <div className={`min-w-[300px] w-60  border rounded-sm border-border-gray bg-menu-bg `}>
       <div
         target='_blank'
         rel='noopener norefferer'
@@ -51,7 +51,7 @@ const SubmissionCard = ({ pr, bounty, refreshBounty }) => {
           </Link>
         </div>
 
-        <div className=' pt-2 text-gray-400 h-20 w-full'>
+        <div className=' pt-2 text-gray-400 h-20 w-full break-word'>
           {pr.body.slice(0, 100)}
           {pr.body && '...'}
         </div>

--- a/components/Submissions/SubmissionCard.js
+++ b/components/Submissions/SubmissionCard.js
@@ -3,12 +3,15 @@ import SubmissionCardAdmin from './SubmissionCardAdmin';
 import Link from 'next/link';
 import Image from 'next/legacy/image';
 import Skeleton from 'react-loading-skeleton';
+import SubmissionWinner from './SubmissionWinner';
 import useWeb3 from '../../hooks/useWeb3';
 
 const SubmissionCard = ({ pr, bounty, refreshBounty }) => {
   const { account } = useWeb3();
   const admin = bounty && bounty?.issuer?.id === account?.toLowerCase();
   const author = pr.author;
+
+  const linkedPrize = bounty.claims.filter((claim) => claim.claimantAsset === pr.url)[0];
   return (
     <div className={`min-w-[300px] w-60  border rounded-sm border-border-gray bg-menu-bg`}>
       <div
@@ -60,8 +63,11 @@ const SubmissionCard = ({ pr, bounty, refreshBounty }) => {
           </div>
         </Link>
       </div>
-
-      {admin && <SubmissionCardAdmin refreshBounty={refreshBounty} pr={pr} bounty={bounty} />}
+      {!linkedPrize ? (
+        admin && <SubmissionCardAdmin refreshBounty={refreshBounty} pr={pr} bounty={bounty} />
+      ) : (
+        <SubmissionWinner linkedPrize={linkedPrize} />
+      )}
     </div>
   );
 };

--- a/components/Submissions/SubmissionCardAdmin.js
+++ b/components/Submissions/SubmissionCardAdmin.js
@@ -1,9 +1,7 @@
-import React, { useContext } from 'react';
-import StoreContext from '../../store/Store/StoreContext';
+import React from 'react';
 import WinnerSelect from './WinnerSelect';
 
 const SubmissionCardAdmin = ({ bounty, pr, refreshBounty }) => {
-  const [appState] = useContext(StoreContext);
   const claimedArr = bounty.claims.map((claim) => parseInt(claim.tier));
   const payoutAndIndex = bounty.payoutSchedule.map((payout, index) => {
     const claimed = claimedArr.includes(index);
@@ -25,67 +23,47 @@ const SubmissionCardAdmin = ({ bounty, pr, refreshBounty }) => {
   });
 
   const linkedPrize = bounty.claims.filter((claim) => claim.claimantAsset === pr.url)[0];
-  let tierWon = null;
-  if (linkedPrize) {
-    tierWon = parseInt(linkedPrize.tier) + 1;
-  }
-
-  const prizeColor = appState.utils.getPrizeColor(tierWon - 1);
   return (
     <div className='border-web-gray border-t px-2'>
-      <h4 className='py-4 text-center w-full font-medium text-xl'>
-        {linkedPrize ? `Winner of tier ${tierWon}` : 'Select Winner'}
-      </h4>
+      <h4 className='py-4 text-center w-full font-medium text-xl'>Select Winner</h4>
       <div className='flex w-full relative h-32'>
-        {tierWon ? (
-          <div className='absolute inset-0   flex justify-center justify-items-center content-center items-center'>
-            <svg className='w-20 h-32' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'>
-              <path
-                fillRule='evenodd'
-                fill={prizeColor}
-                d='M5.09 10.121A5.252 5.252 0 011 5V3.75C1 2.784 1.784 2 2.75 2h2.364c.236-.586.81-1 1.48-1h10.812c.67 0 1.244.414 1.48 1h2.489c.966 0 1.75.784 1.75 1.75V5a5.252 5.252 0 01-4.219 5.149 7.01 7.01 0 01-4.644 5.478l.231 3.003a.326.326 0 00.034.031c.079.065.303.203.836.282.838.124 1.637.81 1.637 1.807v.75h2.25a.75.75 0 010 1.5H4.75a.75.75 0 010-1.5H7v-.75c0-.996.8-1.683 1.637-1.807.533-.08.757-.217.836-.282a.334.334 0 00.034-.031l.231-3.003A7.01 7.01 0 015.09 10.12zM5 3.5H2.75a.25.25 0 00-.25.25V5A3.752 3.752 0 005 8.537V3.5zm6.217 12.457l-.215 2.793-.001.021-.003.043a1.203 1.203 0 01-.022.147c-.05.237-.194.567-.553.86-.348.286-.853.5-1.566.605a.482.482 0 00-.274.136.265.265 0 00-.083.188v.75h7v-.75a.265.265 0 00-.083-.188.483.483 0 00-.274-.136c-.713-.105-1.218-.32-1.567-.604-.358-.294-.502-.624-.552-.86a1.203 1.203 0 01-.025-.19l-.001-.022-.215-2.793a7.076 7.076 0 01-1.566 0zM19 8.578V3.5h2.375a.25.25 0 01.25.25V5c0 1.68-1.104 3.1-2.625 3.578zM6.5 2.594c0-.052.042-.094.094-.094h10.812c.052 0 .094.042.094.094V9a5.5 5.5 0 11-11 0V2.594z'
-              ></path>
-            </svg>
-          </div>
-        ) : (
-          <>
-            {evenPrizes.map((payout, index) => {
-              return (
-                <WinnerSelect
-                  pr={pr}
-                  disabled={linkedPrize}
-                  bounty={bounty}
-                  numberOfPayouts={payoutAndIndex.length}
-                  prize={payout}
-                  key={index}
-                  refreshBounty={refreshBounty}
-                />
-              );
-            })}
-            <WinnerSelect
-              pr={pr}
-              disabled={linkedPrize}
-              refreshBounty={refreshBounty}
-              bounty={bounty}
-              numberOfPayouts={payoutAndIndex.length}
-              prize={firstPrize}
-              key={firstPrize.index}
-            />
-            {oddPrizes.map((payout, index) => {
-              return (
-                <WinnerSelect
-                  refreshBounty={refreshBounty}
-                  pr={pr}
-                  disabled={linkedPrize}
-                  bounty={bounty}
-                  numberOfPayouts={payoutAndIndex.length}
-                  prize={payout}
-                  key={index}
-                />
-              );
-            })}
-          </>
-        )}
+        <>
+          {evenPrizes.map((payout, index) => {
+            return (
+              <WinnerSelect
+                pr={pr}
+                disabled={linkedPrize}
+                bounty={bounty}
+                numberOfPayouts={payoutAndIndex.length}
+                prize={payout}
+                key={index}
+                refreshBounty={refreshBounty}
+              />
+            );
+          })}
+          <WinnerSelect
+            pr={pr}
+            disabled={linkedPrize}
+            refreshBounty={refreshBounty}
+            bounty={bounty}
+            numberOfPayouts={payoutAndIndex.length}
+            prize={firstPrize}
+            key={firstPrize.index}
+          />
+          {oddPrizes.map((payout, index) => {
+            return (
+              <WinnerSelect
+                refreshBounty={refreshBounty}
+                pr={pr}
+                disabled={linkedPrize}
+                bounty={bounty}
+                numberOfPayouts={payoutAndIndex.length}
+                prize={payout}
+                key={index}
+              />
+            );
+          })}
+        </>
       </div>
     </div>
   );

--- a/components/Submissions/SubmissionWinner.js
+++ b/components/Submissions/SubmissionWinner.js
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react';
+import StoreContext from '../../store/Store/StoreContext';
+const SubmissionWinner = ({ linkedPrize }) => {
+  const [appState] = useContext(StoreContext);
+
+  let tierWon = null;
+  if (linkedPrize) {
+    tierWon = parseInt(linkedPrize.tier) + 1;
+  }
+  const prizeColor = appState.utils.getPrizeColor(tierWon - 1);
+
+  return (
+    <div className='border-web-gray border-t px-2'>
+      <h4 className='py-4 text-center w-full font-medium text-xl'>
+        {linkedPrize ? `Winner of tier ${tierWon}` : 'Select Winner'}
+      </h4>
+      <div className='flex w-full relative h-32'>
+        {tierWon && (
+          <div className='absolute inset-0   flex justify-center justify-items-center content-center items-center'>
+            <svg className='w-20 h-32' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'>
+              <path
+                fillRule='evenodd'
+                fill={prizeColor}
+                d='M5.09 10.121A5.252 5.252 0 011 5V3.75C1 2.784 1.784 2 2.75 2h2.364c.236-.586.81-1 1.48-1h10.812c.67 0 1.244.414 1.48 1h2.489c.966 0 1.75.784 1.75 1.75V5a5.252 5.252 0 01-4.219 5.149 7.01 7.01 0 01-4.644 5.478l.231 3.003a.326.326 0 00.034.031c.079.065.303.203.836.282.838.124 1.637.81 1.637 1.807v.75h2.25a.75.75 0 010 1.5H4.75a.75.75 0 010-1.5H7v-.75c0-.996.8-1.683 1.637-1.807.533-.08.757-.217.836-.282a.334.334 0 00.034-.031l.231-3.003A7.01 7.01 0 015.09 10.12zM5 3.5H2.75a.25.25 0 00-.25.25V5A3.752 3.752 0 005 8.537V3.5zm6.217 12.457l-.215 2.793-.001.021-.003.043a1.203 1.203 0 01-.022.147c-.05.237-.194.567-.553.86-.348.286-.853.5-1.566.605a.482.482 0 00-.274.136.265.265 0 00-.083.188v.75h7v-.75a.265.265 0 00-.083-.188.483.483 0 00-.274-.136c-.713-.105-1.218-.32-1.567-.604-.358-.294-.502-.624-.552-.86a1.203 1.203 0 01-.025-.19l-.001-.022-.215-2.793a7.076 7.076 0 01-1.566 0zM19 8.578V3.5h2.375a.25.25 0 01.25.25V5c0 1.68-1.104 3.1-2.625 3.578zM6.5 2.594c0-.052.042-.094.094-.094h10.812c.052 0 .094.042.094.094V9a5.5 5.5 0 11-11 0V2.594z'
+              ></path>
+            </svg>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SubmissionWinner;

--- a/components/Submissions/WinnerSelect.js
+++ b/components/Submissions/WinnerSelect.js
@@ -107,7 +107,7 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr, disab
       return true;
     }
   };
-  const totalPayoutsScheduled = bounty.payoutSchedule.reduce((acc, payout) => {
+  const totalPayoutsScheduled = bounty.payoutSchedule?.reduce((acc, payout) => {
     return ethers.BigNumber.from(acc).add(ethers.BigNumber.from(payout));
   });
 

--- a/components/User/GithubRegistration/AssociationModal.js
+++ b/components/User/GithubRegistration/AssociationModal.js
@@ -173,7 +173,7 @@ const AssociationModal = ({ githubId, user }) => {
             </div>
           )}
           <div>Enter your wallet address:</div>
-          <div className='flex gap-4 asdf s w-80'>
+          <div className='flex gap-4 w-80'>
             <input
               className={'flex-1 input-field'}
               id='name'

--- a/components/User/GithubRegistration/AssociationModal.js
+++ b/components/User/GithubRegistration/AssociationModal.js
@@ -173,7 +173,7 @@ const AssociationModal = ({ githubId, user }) => {
             </div>
           )}
           <div>Enter your wallet address:</div>
-          <div className='flex gap-4 w-80'>
+          <div className='flex gap-4 w-full max-w-[340px]'>
             <input
               className={'flex-1 input-field'}
               id='name'
@@ -187,7 +187,7 @@ const AssociationModal = ({ githubId, user }) => {
           <ToolTipNew toolTipText={'Please enter a valid ethereum address'} hideToolTip={enableLink}>
             <button
               disabled={!enableLink}
-              className={enableLink ? 'w-fit btn-primary' : 'w-fit btn-default'}
+              className={enableLink ? 'max-w-[340px] w-full btn-primary' : 'max-w-[340px] w-full btn-default'}
               onClick={associateExternalIdToAddress}
             >
               Associate Ethereum Address to your Github

--- a/components/Utils/ModalLarge.js
+++ b/components/Utils/ModalLarge.js
@@ -1,8 +1,10 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useContext } from 'react';
 import Cross from '../svg/cross';
+import StoreContext from '../../store/Store/StoreContext';
 
-const ModalLarge = ({ title, children, footerLeft, footerRight, setShowModal, resetState }) => {
+const ModalLarge = ({ title, children, footerLeft, footerRight, setShowModal, resetState, isWalletConnect }) => {
   const modal = useRef();
+  const [appState] = useContext(StoreContext);
   const updateModal = () => {
     resetState();
     setShowModal(false);
@@ -11,7 +13,11 @@ const ModalLarge = ({ title, children, footerLeft, footerRight, setShowModal, re
   useEffect(() => {
     // Courtesy of https://stackoverflow.com/questions/32553158/detect-click-outside-react-component
     function handleClickOutside(event) {
-      if (modal.current && !modal?.current.contains(event.target)) {
+      if (
+        modal.current &&
+        !modal?.current.contains(event.target) &&
+        (!appState.walletConnectModal || isWalletConnect)
+      ) {
         setShowModal(false);
         updateModal();
       }
@@ -24,10 +30,15 @@ const ModalLarge = ({ title, children, footerLeft, footerRight, setShowModal, re
       // Unbind the event listener on clean up
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [modal]);
+  }, [modal, appState.walletConnectModal]);
+
   return (
     <div>
-      <div className='flex justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50'>
+      <div
+        className={`flex justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50 ${
+          isWalletConnect && 'z-[51]'
+        }`}
+      >
         <div ref={modal} className='flex w-[640px] h-[600px] border border-gray-700 rounded-sm bg-[#161B22]'>
           <div className='flex flex-col relative w-full'>
             <button data-testid='cross' className='absolute top-4 right-4 cursor-pointer' onClick={() => updateModal()}>

--- a/components/Utils/ToolTipNew.js
+++ b/components/Utils/ToolTipNew.js
@@ -16,7 +16,7 @@ const ToolTipNew = ({
       {children}
       <div className={`justify-center w-full relative hidden z-50 group-hover:block  ${outerStyles} `}>
         <div className='flex flex-col items-center'>
-          <div className={`flex mt-1 tooltip-triangle absolute ${triangleStyles}`}></div>
+          <div className={`flex mt-0.5 md:mt-1 tooltip-triangle absolute ${triangleStyles}`}></div>
           <div className={`flex tooltip absolute ${relativePosition}`}>
             <div className={`${innerStyles}`}>{toolTipText}</div>
           </div>

--- a/components/Utils/ToolTipNew.js
+++ b/components/Utils/ToolTipNew.js
@@ -8,6 +8,7 @@ const ToolTipNew = ({
   outerStyles,
   innerStyles,
   relativePosition,
+  triangleStyles,
 }) => {
   if (hideToolTip) return children;
   return (
@@ -15,7 +16,7 @@ const ToolTipNew = ({
       {children}
       <div className={`justify-center w-full relative hidden z-50 group-hover:block  ${outerStyles} `}>
         <div className='flex flex-col items-center'>
-          <div className='flex mt-0.5 md:mt-1 tooltip-triangle absolute'></div>
+          <div className={`flex mt-1 tooltip-triangle absolute ${triangleStyles}`}></div>
           <div className={`flex tooltip absolute ${relativePosition}`}>
             <div className={`${innerStyles}`}>{toolTipText}</div>
           </div>

--- a/components/WalletConnect/ConnectModal.js
+++ b/components/WalletConnect/ConnectModal.js
@@ -29,7 +29,13 @@ const ConnectModal = ({ closeModal, setShowModal }) => {
   );
 
   return (
-    <ModalLarge title={'Connect Wallet'} footerRight={btn} setShowModal={setShowModal} resetState={closeModal}>
+    <ModalLarge
+      isWalletConnect={true}
+      title={'Connect Wallet'}
+      footerRight={btn}
+      setShowModal={setShowModal}
+      resetState={closeModal}
+    >
       <div className='p-4'>
         <p className='text-xl pt-2'>
           Connect your wallet to continue with OpenQ. By connecting your wallet you agree with OpenQ{"'"}s{' '}

--- a/pages/user/github/[githubId].js
+++ b/pages/user/github/[githubId].js
@@ -26,7 +26,7 @@ const account = ({ githubId, githubUser, renderError }) => {
           items={[{ name: 'Settings', Svg: Gear }]}
         />
         <div className='w-full border-b h-px border-web-gray'></div>
-        <div className='flex relative max-w-[1440px] w-full mx-auto px-16'>
+        <div className='flex relative max-w-[1440px] mx-auto px-16'>
           <div className='hidden lg:block max-w-[25%] border-web-gray pl-4 left-24 xl:left-20 relative'>
             {githubUser && (
               <div className='flex flex-col items-center gap-4'>
@@ -52,7 +52,7 @@ const account = ({ githubId, githubUser, renderError }) => {
             {internalMenu == 'Settings' && (
               <AssociationModal githubId={githubId} user={githubUser} renderError={renderError} />
             )}
-            <div className='w-60 py-8 lg:hidden'>
+            <div className='xs:w-60 py-8 lg:hidden'>
               <h2 className='text-2xl pb-4 font-semibold'>Sign {authState.githubId ? 'out of' : 'into'} Github</h2>
               <AuthButton />
             </div>

--- a/services/ethers/OpenQClient.js
+++ b/services/ethers/OpenQClient.js
@@ -219,14 +219,23 @@ class OpenQClient {
     return promise;
   }
 
-  async setPayoutScheduleFixed(library, _bountyId, _payoutSchedule, payoutTokenAddress) {
+  async setPayoutScheduleFixed(library, _bountyId, _payoutSchedule, _payoutToken) {
+    const tierVolumesInWei = _payoutSchedule.map((tier) => {
+      const payoutVolumeInWei = tier * 10 ** _payoutToken.decimals;
+      const payoutBigNumberVolumeInWei = ethers.BigNumber.from(
+        payoutVolumeInWei.toLocaleString('fullwide', {
+          useGrouping: false,
+        })
+      );
+      return payoutBigNumberVolumeInWei;
+    });
     const promise = new Promise(async (resolve, reject) => {
       const signer = library.getSigner();
       const contract = this.OpenQ(signer);
       try {
         let txnResponse;
         let txnReceipt;
-        txnResponse = await contract.setPayoutScheduleFixed(_bountyId, _payoutSchedule, payoutTokenAddress);
+        txnResponse = await contract.setPayoutScheduleFixed(_bountyId, tierVolumesInWei, _payoutToken.address);
         txnReceipt = await txnResponse.wait();
         resolve(txnReceipt);
       } catch (error) {

--- a/services/github/graphql/query.js
+++ b/services/github/graphql/query.js
@@ -277,6 +277,7 @@ export const GET_ISSUE_BY_ID = gql`
                 ... on PullRequest {
                   mergedAt
                   url
+                  id
                   merged
                   bodyText
                   body

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -141,7 +141,7 @@ pre {
 	}
 	.tooltip-triangle {
 		@apply content-none block w-0 h-0 absolute border-x-[18px] border-x-transparent border-b-[18px] border-b-[#6e7781] 
-	}
+	}	
 	.break-word{
 		word-break: break-word;
 	}


### PR DESCRIPTION
Closes #970 shows payout schedule sum as budget on fixed price contracts.
Closes #969 hides budget setting on fixed price contracts
Closes #974 refactors out prize notification from admin and shows it to all users.
Closes #980 fixes z-index issues and ensures closing the connect modal when it popped up from another modal doesn't close the underlying modal.
Fixed issue where submission card had a dead link on it.
Closes #972  Adds break-word to text in submission modal.
Closes #975 Shows what the sum of the non-empty tiers, but doesn't allow mint until all tiers some sort of value.
Closes #960 Fixes overflow issues in Github profile page and Fiooter
Closes #932  Added experimental fix, hopefully it works, otherwise users can just use the text inputs.

Fixed issue where payout schedule setting was setting it to low.