### PR TITLE
Miscellaneous Fixes/Changes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 INFURA_KEY=https://mainnet.infura.io/v3/a5bc047f9fa34eeb810474cb70f4ad56
 PROVIDER_URL=https://polygon-mainnet.g.alchemy.com/v2/oVtMdlzWuMxqRtshcF74cnHZ22iXZJGb
 OPENQ_SUBGRAPH_HTTP_URL=http://localhost:8000/subgraphs/name/openqdev/openq
-OPENQ_SUBGRAPH_SSR_HTTP_URL = http://graph_node:8000/subgraphs/name/openqdev/openq
+OPENQ_SUBGRAPH_SSR_HTTP_URL=http://graph_node:8000/subgraphs/name/openqdev/openq
 COIN_API_SSR_URL=http://openq-coinapi:8081
 BASE_URL=http://localhost:3000
 AUTH_URL=http://localhost:3001

--- a/components/FundBounty/SearchTokens/TokenFundBox.js
+++ b/components/FundBounty/SearchTokens/TokenFundBox.js
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 import TokenSearch from './TokenSearch';
 import Image from 'next/legacy/image';
 
-const TokenFundBox = ({ onCurrencySelect, onVolumeChange, token, volume, placeholder, label }) => {
+const TokenFundBox = ({ onCurrencySelect, onVolumeChange, token, volume, placeholder, label, styles }) => {
   const [showTokenSearch, setShowTokenSearch] = useState(false);
 
   return (
-    <div className='flex space-x-4 w-full'>
+    <div className={`flex space-x-4 w-full ${styles}`}>
       <div className='flex w-full flex-row justify-between items-center px-4 input-field-big'>
         <div className={' bg-dark-mode'}>
           <input

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -490,6 +490,7 @@ const MintBountyModal = ({ modalVisibility, types }) => {
                       onVolumeChange={handleGoalChange}
                       volume={goalVolume}
                       token={goalToken}
+                      styles={'flex-col sm:flex-row space-y-4 space-x-0 sm:space-x-4 sm:space-y-0'}
                     />
                   </div>
                 ) : null}
@@ -506,13 +507,14 @@ const MintBountyModal = ({ modalVisibility, types }) => {
                         </div>
                       </ToolTipNew>
                     </div>
-                    <div className='flex-1 w-full px-4'>
+                    <div className='flex-1 w-full px-2'>
                       <TokenFundBox
                         label='split'
                         onCurrencySelect={onCurrencySelect}
                         onVolumeChange={onVolumeChange}
                         token={payoutToken}
                         volume={payoutVolume}
+                        styles={'flex-col sm:flex-row space-y-4 space-x-0 sm:space-x-4 sm:space-y-0'}
                       />
                     </div>
                   </div>

--- a/components/MintBounty/MintBountyModalButton.js
+++ b/components/MintBounty/MintBountyModalButton.js
@@ -19,7 +19,9 @@ export default function MintBountyModalButton({
       disabled={!enableMint && isOnCorrectNetwork}
     >
       {transactionPending ? (
-        <LoadingIcon bg='colored' />
+        <div className='flex items-center gap-2'>
+          Processing... <LoadingIcon bg='colored' />
+        </div>
       ) : !isOnCorrectNetwork ? (
         `Use ${chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network`
       ) : account ? (

--- a/components/Submissions/SubmissionCardAdmin.js
+++ b/components/Submissions/SubmissionCardAdmin.js
@@ -34,7 +34,7 @@ const SubmissionCardAdmin = ({ bounty, pr, refreshBounty }) => {
   return (
     <div className='border-web-gray border-t px-2'>
       <h4 className='py-4 text-center w-full font-medium text-xl'>
-        {linkedPrize ? `Winner of tier ${tierWon}` : 'Select Winner'}
+        {linkedPrize ? `Winner of ${appState.utils.handleSuffix(tierWon)} Place` : 'Select Winner'}
       </h4>
       <div className='flex w-full relative h-32'>
         {tierWon ? (

--- a/components/Utils/ModalDefault.js
+++ b/components/Utils/ModalDefault.js
@@ -30,8 +30,11 @@ const ModalDefault = ({ title, children, footerLeft, footerRight, setShowModal, 
 
   return (
     <div>
-      <div className='flex justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50'>
-        <div ref={modal} className='flex w-[480px] h-[320px] border border-gray-700 rounded-sm bg-[#161B22]'>
+      <div className='flex justify-center items-end sm:items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50'>
+        <div
+          ref={modal}
+          className='flex w-full sm:w-[480px] h-[320px] border border-gray-700 sm:rounded-sm bg-[#161B22]'
+        >
           <div className='flex flex-col relative w-full'>
             <button data-testid='cross' className='absolute top-4 right-4 cursor-pointer' onClick={() => updateModal()}>
               <Cross />

--- a/components/Utils/ModalLarge.js
+++ b/components/Utils/ModalLarge.js
@@ -28,13 +28,16 @@ const ModalLarge = ({ title, children, footerLeft, footerRight, setShowModal, re
   return (
     <div>
       <div className='flex justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50'>
-        <div ref={modal} className='flex w-[640px] h-[600px] border border-gray-700 rounded-sm bg-[#161B22]'>
+        <div
+          ref={modal}
+          className='flex w-full md:w-[640px] h-full md:h-[600px] border border-gray-700 md:rounded-sm bg-[#161B22]'
+        >
           <div className='flex flex-col relative w-full'>
             <button data-testid='cross' className='absolute top-4 right-4 cursor-pointer' onClick={() => updateModal()}>
               <Cross />
             </button>
             <div className='py-2 px-4 border-b border-gray-700 text-2xl w-full'>{title}</div>
-            <div className='w-full h-[500px] overflow-x-hidden overflow-y-auto'>{children}</div>
+            <div className='w-full h-full md:h-[500px] overflow-x-hidden overflow-y-auto'>{children}</div>
             <div className='flex justify-between items-center py-2 px-4 flex-wrap border-t border-gray-700 w-full '>
               <div className='my-1'>{footerLeft}</div>
               <div>{footerRight}</div>


### PR DESCRIPTION
closes #971 replacing tier with 1st Place etc.
closes #977 mobile input field for Set Budget and Reward Split is now large enough
closes #936 fixing indentation of input box to align with rest
closes #894 (and still related to #827) by removing the border-radius on small devices => and also followed the Github primer guidelines for dialogs on Mobile devices: 
https://primer.style/design/components/dialog#dialogs-should-work-well-on-any-device
- Large modals become full screen
- Small modals go to bottom and become full width
closes #935 => adds 'Processing ...' to the mintbountymodal 



![image](https://user-images.githubusercontent.com/75732239/201323942-23883953-9116-445d-82c0-695d9e06d203.png)
![image](https://user-images.githubusercontent.com/75732239/201354083-bdb920bb-cf67-4378-b066-e5ab20877e9b.png)
![image](https://user-images.githubusercontent.com/75732239/201359251-2eedb2c6-dd02-4b96-a488-5cf24782f506.png)
![image](https://user-images.githubusercontent.com/75732239/201359429-eafb3550-190d-437d-b405-79f100b8087b.png)
![image](https://user-images.githubusercontent.com/75732239/201365103-f436a790-f01d-49ff-9eb3-e70625a3ee98.png)


