### PR TITLE
Connect button only if signed in with GitHub + ConnectButton refactor

### DIFF
--- a/__tests__/Claim/ClaimPage.test.js
+++ b/__tests__/Claim/ClaimPage.test.js
@@ -7,8 +7,23 @@ import ClaimPage from '../../components/Claim/ClaimPage';
 import axios from 'axios';
 import InitialState from '../../store/Store/InitialState';
 import userEvent from '@testing-library/user-event';
+import nextRouter from 'next/router';
+
+nextRouter.useRouter = jest.fn();
+const push = jest.fn(() => {
+  return { catch: jest.fn };
+});
 
 describe('ClaimPage', () => {
+  beforeEach(() => {
+    nextRouter.useRouter.mockImplementation(() => ({
+      query: { type: null },
+      prefetch: jest.fn(() => {
+        return { catch: jest.fn };
+      }),
+      push,
+    }));
+  });
   const bounty = {
     __typename: 'Bounty',
     bountyAddress: '0x1f191c4166865882b26551fb8618668b7a67d0fb',

--- a/__tests__/MintBounty/MintBountyModalButton.test.js
+++ b/__tests__/MintBounty/MintBountyModalButton.test.js
@@ -15,13 +15,6 @@ describe('MintBountyModalButton', () => {
 
     expect(screen.getByRole('button', { name: 'Deploy Contract' }).disabled).toBe(true);
   });
-  it('should be enabled to switch network.', () => {
-    // ARRANGE
-    render(<MintBountyModalButton account={true} enableMint={false} isOnCorrectNetwork={false} />);
-
-    const button = screen.queryByRole('button', { name: 'Use Localhost:8545 Network' });
-    expect(button).toBeInTheDocument();
-  });
   it('should disappear when enabled transaction pending.', async () => {
     // ARRANGE
     render(

--- a/__tests__/RefundBounty/DepositCard.test.js
+++ b/__tests__/RefundBounty/DepositCard.test.js
@@ -117,17 +117,17 @@ describe('DepositCard', () => {
       expect(nullish).toHaveLength(0);
     });
 
-    it('should render change network button when not on right network', async () => {
+    /* it('should render change network button when not on right network', async () => {
       // ARRANGE
       render(<DepositCard deposit={deposit} isOnCorrectNetwork={false} />);
-      const chgeNetworkBtn = await screen.findByRole('button', { name: /Change Network/i });
+      const chgeNetworkBtn = await screen.findByRole('button', { name: /Network/i });
 
       // ASSERT
       expect(chgeNetworkBtn).toBeInTheDocument();
 
       const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
       expect(nullish).toHaveLength(0);
-    });
+    }); */
   };
 
   deposits.forEach((deposit) => test(deposit));

--- a/__tests__/WalletConnect/ConnectButton.test.js
+++ b/__tests__/WalletConnect/ConnectButton.test.js
@@ -1,4 +1,3 @@
-// test/component/WatchButton/WatchButton.test.js
 /**
  * @jest-environment jsdom
  */
@@ -7,43 +6,8 @@ import { render, screen } from '../../test-utils';
 import ConnectButton from '../../components/WalletConnect/ConnectButton';
 import nextRouter from 'next/router';
 // Test cases for full balances, empty balances, and undefined balances.
-const subgraphBounty = {
-  __typename: 'Bounty',
-  bountyAddress: '0x13f7816057de7256daf5028eaf8e79775d3a27a3',
-  bountyId: 'I_kwDOGWnnz85I9Ahl',
-  bountyMintTime: '1654041044',
-  bountyClosedTime: null,
-  status: 'OPEN',
-  claimedTransactionHash: null,
-  deposits: [
-    {
-      __typename: 'Deposit',
-      id: '0xd024e550ba670d71f23f336c63ed0aacda946c6836f416028ffa0888b1a4b691',
-      refunded: false,
-      refundTime: null,
-      expiration: '2592000',
-      tokenAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
-      volume: '12000000000000000000',
-      sender: {
-        __typename: 'User',
-        id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-      },
-      receiveTime: '1642021044',
-    },
-  ],
-  issuer: {
-    __typename: 'User',
-    id: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
-  },
-  bountyTokenBalances: [
-    {
-      __typename: 'BountyFundedTokenBalance',
-      volume: '12000000000000000000',
-      tokenAddress: '0x5fbdb2315678afecb367f032d93f642f64180aa3',
-    },
-  ],
-};
-describe('WatchButton', () => {
+
+describe('ConnectButton', () => {
   // Test cases for
 
   const push = jest.fn(() => {
@@ -67,18 +31,9 @@ describe('WatchButton', () => {
     }));
   });
 
-  it('should render watch button', async () => {
-    // ARRANGE
-    render(<ConnectButton bounty={subgraphBounty} watchingState={false} />);
-
-    // ASSERT
-    const nullish = [...screen.queryAllByRole(/null/), ...screen.queryAllByRole(/undefined/)];
-    expect(nullish).toHaveLength(0);
-  });
-
   it('should open modal and display link to profile.', async () => {
     // ARRANGE
-    render(<ConnectButton />);
+    render(<ConnectButton nav={true} />);
 
     // ASSERT
     const accountBtn = screen.getByRole('button');

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -11,6 +11,7 @@ import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
 import ClaimText from './ClaimText';
 import BountyClosed from '../BountyClosed/BountyClosed';
 import TokenSearch from '../FundBounty/SearchTokens/TokenSearch';
+import ConnectButton from '../WalletConnect/ConnectButton';
 
 const AdminPage = ({ bounty, refreshBounty }) => {
   // Context
@@ -261,9 +262,12 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                         volume={volume}
                       />
                     </div>
-                    <button className='btn-default mx-4' type='button' onClick={setBudget}>
-                      Set New Budget
-                    </button>
+                    <ConnectButton nav={false} needsGithub={false} />
+                    {isOnCorrectNetwork && account && (
+                      <button className='btn-default' type='button' onClick={setBudget}>
+                        Set New Budget
+                      </button>
+                    )}
                   </>
                 )}
 
@@ -335,27 +339,24 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                         setEnableContest={setEnableContest}
                       />
                     </div>
-                    <ToolTipNew
-                      hideToolTip={(enableContest && isOnCorrectNetwork && account) || isLoading}
-                      toolTipText={
-                        account && isOnCorrectNetwork && !enableContest
-                          ? 'Please make sure the sum of tier percentages adds up to 100.'
-                          : isOnCorrectNetwork
-                          ? 'Connect your wallet to mint a contract!'
-                          : 'Please switch to the correct network to mint a contract.'
-                      }
-                    >
-                      <div className='px-4'>
-                        <button
-                          className={`w-full btn-default ${enableContest ? 'cursor-pointer' : 'cursor-not-allowed'}`}
-                          type='button'
-                          onClick={setPayoutSchedule}
-                          disabled={!enableContest}
-                        >
-                          Set New Payout Schedule
-                        </button>
-                      </div>
-                    </ToolTipNew>
+                    <ConnectButton nav={false} needsGithub={false} />
+                    {isOnCorrectNetwork && account && (
+                      <ToolTipNew
+                        hideToolTip={enableContest || isLoading}
+                        toolTipText={!enableContest && 'Please make sure the sum of tier percentages adds up to 100.'}
+                      >
+                        <div className='px-4'>
+                          <button
+                            className={`w-full btn-default ${enableContest ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+                            type='button'
+                            onClick={setPayoutSchedule}
+                            disabled={!enableContest}
+                          >
+                            Set New Payout Schedule
+                          </button>
+                        </div>
+                      </ToolTipNew>
+                    )}
                   </>
                 ) : bounty.bountyType == '1' ? (
                   <>
@@ -369,9 +370,12 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                         volume={payoutVolume}
                       />
                     </div>
-                    <button className='btn-default' type='button' onClick={setPayout}>
-                      Set Payout
-                    </button>
+                    <ConnectButton nav={false} needsGithub={false} />
+                    {isOnCorrectNetwork && account && (
+                      <button className='btn-default' type='button' onClick={setPayout}>
+                        Set Payout
+                      </button>
+                    )}
 
                     <h2 className='text-2xl text-[#f85149] border-b border-gray-700 pb-4'>
                       Close Split Price Contract
@@ -379,9 +383,12 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                     <div className='flex justify-between items-center gap-2'>
                       Once you close this split price contract, there is no going back. Please be certain.
                     </div>
-                    <button className='btn-danger' type='button' onClick={closeOngoing}>
-                      Close Split Price Contract
-                    </button>
+                    <ConnectButton nav={false} needsGithub={false} />
+                    {isOnCorrectNetwork && account && (
+                      <button className='btn-danger' type='button' onClick={closeOngoing}>
+                        Close Split Price Contract
+                      </button>
+                    )}
                   </>
                 ) : null}
 

--- a/components/Admin/AdminPage.js
+++ b/components/Admin/AdminPage.js
@@ -262,7 +262,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                         volume={volume}
                       />
                     </div>
-                    <ConnectButton nav={false} needsGithub={false} />
+                    <ConnectButton nav={false} needsGithub={false} centerStyles={true} />
                     {isOnCorrectNetwork && account && (
                       <button className='btn-default' type='button' onClick={setBudget}>
                         Set New Budget
@@ -339,7 +339,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                         setEnableContest={setEnableContest}
                       />
                     </div>
-                    <ConnectButton nav={false} needsGithub={false} />
+                    <ConnectButton nav={false} needsGithub={false} centerStyles={true} />
                     {isOnCorrectNetwork && account && (
                       <ToolTipNew
                         hideToolTip={enableContest || isLoading}
@@ -370,7 +370,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                         volume={payoutVolume}
                       />
                     </div>
-                    <ConnectButton nav={false} needsGithub={false} />
+                    <ConnectButton nav={false} needsGithub={false} centerStyles={true} />
                     {isOnCorrectNetwork && account && (
                       <button className='btn-default' type='button' onClick={setPayout}>
                         Set Payout
@@ -383,7 +383,7 @@ const AdminPage = ({ bounty, refreshBounty }) => {
                     <div className='flex justify-between items-center gap-2'>
                       Once you close this split price contract, there is no going back. Please be certain.
                     </div>
-                    <ConnectButton nav={false} needsGithub={false} />
+                    <ConnectButton nav={false} needsGithub={false} centerStyles={true} />
                     {isOnCorrectNetwork && account && (
                       <button className='btn-danger' type='button' onClick={closeOngoing}>
                         Close Split Price Contract

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -143,7 +143,7 @@ const ClaimPage = ({ bounty, refreshBounty, price, split }) => {
                   <ConnectButton
                     needsGithub={true}
                     nav={false}
-                    tooltipAction={'to claim this contract!'}
+                    tooltipAction={'claim this contract!'}
                     hideSignOut={true}
                   />
 

--- a/components/Claim/ClaimPage.js
+++ b/components/Claim/ClaimPage.js
@@ -12,7 +12,6 @@ import {
   CONFIRM_CLAIM,
 } from './ClaimStates';
 import useAuth from '../../hooks/useAuth';
-import AuthButton from '../Authentication/AuthButton';
 import useWeb3 from '../../hooks/useWeb3';
 import ClaimLoadingModal from './ClaimLoadingModal';
 import CopyAddressToClipboard from '../Copy/CopyAddressToClipboard';
@@ -21,6 +20,7 @@ import useEns from '../../hooks/useENS';
 import ToolTipNew from '../Utils/ToolTipNew';
 import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
 import StoreContext from '../../store/Store/StoreContext';
+import ConnectButton from '../WalletConnect/ConnectButton';
 
 const ClaimPage = ({ bounty, refreshBounty, price, split }) => {
   const { url } = bounty;
@@ -55,13 +55,6 @@ const ClaimPage = ({ bounty, refreshBounty, price, split }) => {
   const [authState] = useAuth();
 
   // Methods
-  const connectWallet = () => {
-    const payload = {
-      type: 'CONNECT_WALLET',
-      payload: true,
-    };
-    dispatch(payload);
-  };
 
   const claimBounty = async () => {
     setClaimState(CHECKING_WITHDRAWAL_ELIGIBILITY);
@@ -147,44 +140,36 @@ const ClaimPage = ({ bounty, refreshBounty, price, split }) => {
                       We noticed you are not signed into Github. You must sign to verify and claim an issue!
                     </div>
                   ) : null}
+                  <ConnectButton
+                    needsGithub={true}
+                    nav={false}
+                    tooltipAction={'to claim this contract!'}
+                    hideSignOut={true}
+                  />
 
-                  <div className='flex flex-col space-y-5'>
-                    <ToolTipNew
-                      groupStyles={'w-full'}
-                      outerStyles='flex w-full items-center'
-                      hideToolTip={account && isOnCorrectNetwork && authState.isAuthenticated && price > 0}
-                      toolTipText={
-                        account && isOnCorrectNetwork && authState.isAuthenticated && price > 0
-                          ? "Please indicate the volume you'd like to claim with."
-                          : account && authState.isAuthenticated && price > 0
-                          ? 'Please switch to the correct network to claim this contract.'
-                          : authState.isAuthenticated && price > 0
-                          ? 'Connect your wallet to claim this contract!'
-                          : price > 0
-                          ? 'Connect your GitHub account to claim this contract!'
-                          : 'There are no funds locked to claim, contact the maintainer of this issue.'
-                      }
-                    >
-                      <button
-                        type='submit'
-                        className={
-                          (isOnCorrectNetwork && authState.isAuthenticated && price > 0) || !account
-                            ? 'btn-primary cursor-pointer w-full px-8 whitespace-nowrap'
-                            : 'btn-default cursor-not-allowed w-full px-8 whitespace-nowrap'
-                        }
-                        disabled={(!isOnCorrectNetwork || !authState.isAuthenticated || !(price > 0)) && account}
-                        onClick={account ? () => setShowClaimLoadingModal(true) : connectWallet}
+                  {account && isOnCorrectNetwork && authState.isAuthenticated && (
+                    <div className='flex flex-col space-y-5'>
+                      <ToolTipNew
+                        groupStyles={'w-full'}
+                        outerStyles='flex w-full items-center'
+                        hideToolTip={price > 0}
+                        toolTipText={'There are no funds locked to claim, contact the maintainer of this issue.'}
                       >
-                        {account ? 'Claim' : 'Connect Wallet'}
-                      </button>
-                    </ToolTipNew>
-                  </div>
-                  <div className='flex items-center col-span-3 pb-8'>
-                    <AuthButton
-                      hideSignOut={true}
-                      redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/contract/${bounty.bountyId}/${bounty.bountyAddress}`}
-                    />
-                  </div>
+                        <button
+                          type='submit'
+                          className={
+                            price > 0
+                              ? 'btn-primary cursor-pointer w-full px-8 whitespace-nowrap'
+                              : 'btn-default cursor-not-allowed w-full px-8 whitespace-nowrap'
+                          }
+                          disabled={!(price > 0)}
+                          onClick={() => setShowClaimLoadingModal(true)}
+                        >
+                          Claim
+                        </button>
+                      </ToolTipNew>
+                    </div>
+                  )}
                   {showClaimLoadingModal && (
                     <ClaimLoadingModal
                       confirmMethod={claimBounty}

--- a/components/FundBounty/FundPage.js
+++ b/components/FundBounty/FundPage.js
@@ -15,7 +15,7 @@ import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
 import SelectableNFT from './SelectableNFT';
 import NFTFundModal from './NFTFundModal.js';
 import Cross from '../svg/cross';
-import chainIdDeployEnvMap from '../../components/WalletConnect/chainIdDeployEnvMap';
+import ConnectButton from '../WalletConnect/ConnectButton';
 
 const FundPage = ({ bounty, refreshBounty }) => {
   const [volume, setVolume] = useState('');
@@ -40,7 +40,7 @@ const FundPage = ({ bounty, refreshBounty }) => {
     path: 'https://wallet-asset.matic.network/img/tokens/matic.svg',
   };
   // Context
-  const [appState, dispatch] = useContext(StoreContext);
+  const [appState] = useContext(StoreContext);
   const { logger, openQClient, utils } = appState;
   const { library, account } = useWeb3();
 
@@ -108,14 +108,6 @@ const FundPage = ({ bounty, refreshBounty }) => {
   const closeModal = () => {
     setShowApproveTransferModal();
     setPickedNft();
-  };
-
-  const connectWallet = () => {
-    const payload = {
-      type: 'CONNECT_WALLET',
-      payload: true,
-    };
-    dispatch(payload);
   };
 
   const openInvoicingModal = () => {
@@ -274,15 +266,6 @@ const FundPage = ({ bounty, refreshBounty }) => {
     if (e.target.value === '') setDepositPeriodDays('0');
   };
 
-  const addOrSwitchNetwork = () => {
-    window.ethereum
-      .request({
-        method: 'wallet_addEthereumChain',
-        params: chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['params'],
-      })
-      .catch((err) => appState.logger.error(err, account));
-  };
-
   // Render
   return (
     <>
@@ -369,40 +352,32 @@ const FundPage = ({ bounty, refreshBounty }) => {
                       </div>
                     </div>
                   )}
-                  <ToolTipNew
-                    relativePosition={'left-0'}
-                    outerStyles={'-top-1 '}
-                    groupStyles={'w-min'}
-                    innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
-                    hideToolTip={account && isOnCorrectNetwork && !loadingClosedOrZero}
-                    toolTipText={
-                      account && isOnCorrectNetwork && !(depositPeriodDays > 0)
-                        ? "Please indicate how many days you'd like to fund your contract for."
-                        : account && isOnCorrectNetwork && isContest && nftTier === '' && pickedNft
-                        ? 'Please select an elgible tier to fund the nft to.'
-                        : account && isOnCorrectNetwork
-                        ? "Please indicate the volume you'd like to fund with. Must be between 0.0000001 and 1,000,000."
-                        : account
-                        ? 'Please switch to the correct network to fund this contract.'
-                        : 'Connect your wallet to fund this contract!'
-                    }
-                  >
-                    <button
-                      className={`${fundButtonClasses} py-1.5`}
-                      disabled={loadingClosedOrZero && account && isOnCorrectNetwork}
-                      type='button'
-                      onClick={!account ? connectWallet : !isOnCorrectNetwork ? addOrSwitchNetwork : openFund}
+                  <ConnectButton needsGithub={false} nav={false} tooltipAction={'to fund this contract!'} />
+                  {account && isOnCorrectNetwork && (
+                    <ToolTipNew
+                      relativePosition={'left-0'}
+                      outerStyles={'-top-1 '}
+                      groupStyles={'w-min'}
+                      innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
+                      hideToolTip={!loadingClosedOrZero}
+                      toolTipText={
+                        !(depositPeriodDays > 0)
+                          ? "Please indicate how many days you'd like to fund your contract for."
+                          : isContest && nftTier === '' && pickedNft
+                          ? 'Please select an elgible tier to send the nft to.'
+                          : "Please indicate the volume you'd like to fund with. Must be between 0.0000001 and 1,000,000."
+                      }
                     >
-                      <div className='text-center whitespace-nowrap w-full'>
-                        {/* {account && isOnCorrectNetwork ? buttonText : 'Connect Wallet'} */}
-                        {!account
-                          ? 'Connect Wallet'
-                          : !isOnCorrectNetwork
-                          ? `Use ${chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network`
-                          : buttonText}
-                      </div>
-                    </button>
-                  </ToolTipNew>
+                      <button
+                        className={`${fundButtonClasses} py-1.5`}
+                        disabled={loadingClosedOrZero}
+                        type='button'
+                        onClick={openFund}
+                      >
+                        <div className='text-center whitespace-nowrap w-full'>{buttonText}</div>
+                      </button>
+                    </ToolTipNew>
+                  )}
                 </div>
                 {pickedNft && (
                   <div className='w-60 relative -top-2 rounded-md '>

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -15,10 +15,13 @@ import NavLinks from './NavLinks';
 import LoadingBar from '../Loading/LoadingBar';
 import LoadingThread from '../Loading/LoadingThread.js';
 import ContractWizard from '../ContractWizard/ContractWizard.js';
+import useAuth from '../../hooks/useAuth';
+import AuthButton from '../Authentication/AuthButton.js';
 
 const Navigation = () => {
   const { account } = useWeb3();
   const [appState] = useContext(StoreContext);
+  const [authState] = useAuth();
   const [openMenu, setOpenMenu] = useState(false);
   const [quickSearch, setQuickSearch] = useState('');
   const [items, setItems] = useState([]);
@@ -171,7 +174,11 @@ const Navigation = () => {
           </div>
           <div className='flex items-center text-[0.8rem] lg:text-[1rem]'>
             <div className='pr-4'>
-              <ConnectButton />
+              {!authState.isAuthenticated ? (
+                <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} />
+              ) : (
+                <ConnectButton />
+              )}
             </div>
           </div>
         </div>

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -16,7 +16,6 @@ import LoadingBar from '../Loading/LoadingBar';
 import LoadingThread from '../Loading/LoadingThread.js';
 import ContractWizard from '../ContractWizard/ContractWizard.js';
 import useAuth from '../../hooks/useAuth';
-import AuthButton from '../Authentication/AuthButton.js';
 
 const Navigation = () => {
   const { account } = useWeb3();
@@ -174,11 +173,7 @@ const Navigation = () => {
           </div>
           <div className='flex items-center text-[0.8rem] lg:text-[1rem]'>
             <div className='pr-4'>
-              {!authState.isAuthenticated ? (
-                <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} />
-              ) : (
-                <ConnectButton />
-              )}
+              <ConnectButton needsGithub={true} isAuthenticated={authState.isAuthenticated} />
             </div>
           </div>
         </div>

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -15,12 +15,10 @@ import NavLinks from './NavLinks';
 import LoadingBar from '../Loading/LoadingBar';
 import LoadingThread from '../Loading/LoadingThread.js';
 import ContractWizard from '../ContractWizard/ContractWizard.js';
-import useAuth from '../../hooks/useAuth';
 
 const Navigation = () => {
   const { account } = useWeb3();
   const [appState] = useContext(StoreContext);
-  const [authState] = useAuth();
   const [openMenu, setOpenMenu] = useState(false);
   const [quickSearch, setQuickSearch] = useState('');
   const [items, setItems] = useState([]);
@@ -173,7 +171,7 @@ const Navigation = () => {
           </div>
           <div className='flex items-center text-[0.8rem] lg:text-[1rem]'>
             <div className='pr-4'>
-              <ConnectButton needsGithub={true} isAuthenticated={authState.isAuthenticated} />
+              <ConnectButton needsGithub={true} nav={true} />
             </div>
           </div>
         </div>

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -21,6 +21,7 @@ import TokenFundBox from '../FundBounty/SearchTokens/TokenFundBox';
 import SubMenu from '../Utils/SubMenu';
 import TokenSearch from '../FundBounty/SearchTokens/TokenSearch';
 import ModalLarge from '../Utils/ModalLarge';
+import ConnectButton from '../WalletConnect/ConnectButton';
 
 const MintBountyModal = ({ modalVisibility, types }) => {
   // Context
@@ -365,49 +366,33 @@ const MintBountyModal = ({ modalVisibility, types }) => {
   );
 
   const btn = !error && (
-    <ToolTipNew
-      groupStyles={''}
-      outerStyles={'hover:hidden -top-20 md:top-auto'}
-      triangleStyles={'mt-7 md:mt-1 rotate-180 md:rotate-0 '}
-      hideToolTip={
-        (enableContest &&
-          enableMint &&
-          isOnCorrectNetwork &&
-          !issue?.closed &&
-          account &&
-          issue?.url.includes('/issues/')) ||
-        isLoading
-      }
-      toolTipText={
-        issue?.closed && issue?.url.includes('/issues/')
-          ? 'Issue closed'
-          : account && isOnCorrectNetwork && (!enableMint || !issue?.url.includes('/issues/'))
-          ? 'Please choose an elgible issue.'
-          : currentSum !== sum
-          ? 'Please make sure each tier gets a percentage.'
-          : !enableContest
-          ? 'Please make sure the sum of tier percentages adds up to 100.'
-          : isOnCorrectNetwork
-          ? 'Connect your wallet to mint a contract!'
-          : 'Please switch to the correct network to mint a contract.'
-      }
-    >
-      <MintBountyModalButton
-        mintBounty={!isOnCorrectNetwork ? addOrSwitchNetwork : account ? mintBounty : connectWallet}
-        account={account}
-        isOnCorrectNetwork={isOnCorrectNetwork}
-        enableMint={
-          (enableContest &&
-            enableMint &&
-            isOnCorrectNetwork &&
-            !issue?.closed &&
-            issue?.url.includes('/issues/') &&
-            !isLoading) ||
-          !account
-        }
-        transactionPending={isLoading}
-      />
-    </ToolTipNew>
+    <>
+      <ConnectButton nav={false} needsGithub={false} tooltipAction={'mint a contract.'} />
+      {account && isOnCorrectNetwork && (
+        <ToolTipNew
+          outerStyles={'hover:hidden -top-20 md:top-auto'}
+          triangleStyles={'mt-7 md:mt-1 rotate-180 md:rotate-0 '}
+          hideToolTip={(enableContest && enableMint && !issue?.closed && issue?.url.includes('/issues/')) || isLoading}
+          toolTipText={
+            issue?.closed && issue?.url.includes('/issues/')
+              ? 'Issue closed'
+              : !enableMint || !issue?.url.includes('/issues/')
+              ? 'Please choose an elgible issue.'
+              : currentSum !== sum
+              ? 'Please make sure each tier gets a percentage.'
+              : !enableContest
+              ? 'Please make sure the sum of tier percentages adds up to 100.'
+              : null
+          }
+        >
+          <MintBountyModalButton
+            mintBounty={mintBounty}
+            enableMint={enableContest && enableMint && !issue?.closed && issue?.url.includes('/issues/') && !isLoading}
+            transactionPending={isLoading}
+          />
+        </ToolTipNew>
+      )}
+    </>
   );
 
   // Render

--- a/components/MintBounty/MintBountyModal.js
+++ b/components/MintBounty/MintBountyModal.js
@@ -3,7 +3,6 @@ import React, { useEffect, useState, useContext, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { ethers } from 'ethers';
 import Image from 'next/image';
-import chainIdDeployEnvMap from '../../components/WalletConnect/chainIdDeployEnvMap';
 import { PersonAddIcon, PersonIcon, PeopleIcon } from '@primer/octicons-react';
 
 // Custom
@@ -229,23 +228,6 @@ const MintBountyModal = ({ modalVisibility, types }) => {
     }
   };
 
-  const connectWallet = () => {
-    const payload = {
-      type: 'CONNECT_WALLET',
-      payload: true,
-    };
-    dispatch(payload);
-  };
-
-  const addOrSwitchNetwork = () => {
-    window.ethereum
-      .request({
-        method: 'wallet_addEthereumChain',
-        params: chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['params'],
-      })
-      .catch((err) => appState.logger.error(err, account));
-  };
-
   const closeModal = () => {
     setIssue();
     setUrl();
@@ -423,19 +405,6 @@ const MintBountyModal = ({ modalVisibility, types }) => {
                 styles={'justify-center'}
                 vertical={true}
               />
-              {/* <div className='pb-2 pt-8'>Templates</div>
-              <SubMenu
-                items={[
-                  { name: 'Fixed Price Contract', Svg: PersonIcon },
-                  { name: 'Learn2Earn', Svg: PersonAddIcon },
-                  { name: 'Competition', Svg: PeopleIcon },
-                  // { name: 'Fixed Contest', Svg: PeopleIcon },
-                ]}
-                internalMenu={category}
-                updatePage={setCategory}
-                styles={'justify-center'}
-                vertical={true}
-              /> */}
             </div>
             <div className='overflow-y-auto px-2'>
               <h3 className='text-xl pt-2'>

--- a/components/MintBounty/MintBountyModalButton.js
+++ b/components/MintBounty/MintBountyModalButton.js
@@ -1,33 +1,20 @@
 import React from 'react';
 import LoadingIcon from '../Loading/ButtonLoadingIcon';
-import chainIdDeployEnvMap from '../../components/WalletConnect/chainIdDeployEnvMap';
 
-export default function MintBountyModalButton({
-  enableMint,
-  transactionPending,
-  mintBounty,
-  account,
-  isOnCorrectNetwork,
-}) {
+export default function MintBountyModalButton({ enableMint, transactionPending, mintBounty }) {
   return (
     <button
-      className={`${
-        enableMint || !isOnCorrectNetwork ? 'btn-primary cursor-pointer' : 'btn-primary cursor-not-allowed'
-      }`}
+      className={`${enableMint ? 'btn-primary cursor-pointer' : 'btn-primary cursor-not-allowed'}`}
       type='button'
       onClick={() => mintBounty()}
-      disabled={!enableMint && isOnCorrectNetwork}
+      disabled={!enableMint}
     >
       {transactionPending ? (
         <div className='flex items-center gap-2'>
           Processing... <LoadingIcon bg='colored' />
         </div>
-      ) : !isOnCorrectNetwork ? (
-        `Use ${chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network`
-      ) : account ? (
-        'Deploy Contract'
       ) : (
-        'Connect Wallet'
+        'Deploy Contract'
       )}
     </button>
   );

--- a/components/RefundBounty/DepositCard.js
+++ b/components/RefundBounty/DepositCard.js
@@ -7,7 +7,7 @@ import ToolTipNew from '../Utils/ToolTipNew';
 import { ethers } from 'ethers';
 import useWeb3 from '../../hooks/useWeb3';
 import Link from 'next/link';
-import chainIdDeployEnvMap from '../../components/WalletConnect/chainIdDeployEnvMap';
+import ConnectButton from '../WalletConnect/ConnectButton';
 
 const DepositCard = ({
   deposit,
@@ -18,7 +18,6 @@ const DepositCard = ({
   isOnCorrectNetwork,
   onDepositPeriodChanged,
   depositPeriodDays,
-  account,
 }) => {
   // Context
   const [appState] = useContext(StoreContext);
@@ -44,17 +43,8 @@ const DepositCard = ({
     getNft();
   }, [deposit, library]);
 
-  const addOrSwitchNetwork = () => {
-    window.ethereum
-      .request({
-        method: 'wallet_addEthereumChain',
-        params: chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['params'],
-      })
-      .catch((err) => appState.logger.error(err, account));
-  };
-
   return (
-    <div className='flex flex-col items-center w-full md:border rounded-sm border-gray-700 text-primary'>
+    <div className='flex flex-col items-center w-full md:border rounded-sm border-gray-700 text-primary hover:bg-[#21262d]'>
       <div className='flex justify-center w-full md:bg-[#161b22] md:border-b border-gray-700 pb-1 rounded-t-sm'>
         {deposit.isNft && NFT ? (
           <Link href={NFT.uri} className='underline'>
@@ -67,11 +57,7 @@ const DepositCard = ({
         )}
       </div>
 
-      <div
-        className={
-          'pt-3 flex flex-col md:flex-row w-full items-center justify-between px-8 sm:px-6 pb-4 hover:bg-[#21262d]'
-        }
-      >
+      <div className={'pt-3 flex flex-col md:flex-row w-full items-center justify-between px-8 sm:px-6 pb-4'}>
         <div className='flex flex-col space-y-2'>
           <div className='text-left  py-2'>
             Deposited on: {appState.utils.formatUnixDate(parseInt(deposit.receiveTime))}
@@ -87,94 +73,73 @@ const DepositCard = ({
             </div>
           )}
         </div>
-
-        <div className='flex flex-col space-y-3 w-44 pl-3 text-primary'>
-          {status === 'refundable' && isOnCorrectNetwork && (
-            <ToolTipNew
-              outerStyles='flex'
-              hideToolTip={isOnCorrectNetwork}
-              toolTipText={'Please switch to the correct network to refund this deposit.'}
-            >
-              <button
-                onClick={() => refundBounty(deposit.id)}
-                disabled={!isOnCorrectNetwork}
-                className={`${isOnCorrectNetwork ? 'btn-default w-full' : 'btn-default cursor-not-allowed w-full'}`}
-              >
-                Refund
-              </button>
-            </ToolTipNew>
-          )}
-          {status !== 'refunded' && !closed && (
-            <>
-              {expanded && isOnCorrectNetwork ? (
-                <div className=' text-primary flex flex-col md:flex-row md:space-x-2 items-center'>
-                  <div className='flex w-full input-field-big pl-4 justify-between'>
-                    <div className=' flex items-center'>
-                      <ToolTipNew
-                        innerStyles={'whitespace-normal w-40'}
-                        toolTipText={
-                          status === 'refundable'
-                            ? 'How many days you will relock this deposit for.'
-                            : "How many days you will add to this deposit's current lock period."
-                        }
-                      >
-                        <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
-                          ?
+        {isOnCorrectNetwork && (
+          <>
+            <div className='flex flex-col space-y-3 w-44 pl-3 text-primary'>
+              {status === 'refundable' && (
+                <button onClick={() => refundBounty(deposit.id)} className={'btn-default w-full'}>
+                  Refund
+                </button>
+              )}
+              {status !== 'refunded' && !closed && (
+                <>
+                  {expanded ? (
+                    <div className=' text-primary flex flex-col md:flex-row md:space-x-2 items-center'>
+                      <div className='flex w-full input-field-big pl-4 justify-between'>
+                        <div className=' flex items-center'>
+                          <ToolTipNew
+                            innerStyles={'whitespace-normal w-40'}
+                            toolTipText={
+                              status === 'refundable'
+                                ? 'How many days you will relock this deposit for.'
+                                : "How many days you will add to this deposit's current lock period."
+                            }
+                          >
+                            <div className='cursor-help rounded-full border border-[#c9d1d9] aspect-square leading-4 h-4 box-content text-center font-bold text-primary'>
+                              ?
+                            </div>
+                          </ToolTipNew>
                         </div>
+
+                        <input
+                          className='flex w-full md:w-12 text-primary text-right number outline-none bg-dark-mode'
+                          autoComplete='off'
+                          value={depositPeriodDays || 0}
+                          name={deposit.id}
+                          id='deposit-period'
+                          onChange={onDepositPeriodChanged}
+                          placeholder='0'
+                        />
+                      </div>
+                      <ToolTipNew
+                        outerStyles='flex w-full items-center'
+                        hideToolTip={depositPeriodDays > 0}
+                        toolTipText={"Please indicate how many days you'd like to extend this deposit for."}
+                      >
+                        <button
+                          onClick={() => extendBounty(deposit.id, formattedVolume, tokenMetadata.symbol)}
+                          disabled={!(depositPeriodDays > 0)}
+                          className={`flex mt-3 md:mt-0 text-center w-full px-3 justify-center ${
+                            depositPeriodDays > 0 ? 'btn-primary cursor-pointer p-1' : 'btn-default cursor-not-allowed'
+                          }`}
+                        >
+                          Extend
+                        </button>
                       </ToolTipNew>
                     </div>
-
-                    <input
-                      className='flex w-full md:w-12 text-primary text-right number outline-none bg-dark-mode'
-                      autoComplete='off'
-                      value={depositPeriodDays || 0}
-                      name={deposit.id}
-                      id='deposit-period'
-                      onChange={onDepositPeriodChanged}
-                      placeholder='0'
-                    />
-                  </div>
-                  <ToolTipNew
-                    outerStyles='flex w-full items-center'
-                    hideToolTip={isOnCorrectNetwork && depositPeriodDays > 0}
-                    toolTipText={
-                      !isOnCorrectNetwork
-                        ? 'Please switch to the correct network to extend this bounty.'
-                        : !(depositPeriodDays > 0)
-                        ? "Please indicate how many days you'd like to extend this deposit for."
-                        : null
-                    }
-                  >
-                    <button
-                      onClick={() => extendBounty(deposit.id, formattedVolume, tokenMetadata.symbol)}
-                      disabled={!isOnCorrectNetwork || !(depositPeriodDays > 0)}
-                      className={`flex mt-3 md:mt-0 text-center w-full px-3 justify-center ${
-                        isOnCorrectNetwork && depositPeriodDays > 0
-                          ? 'btn-primary cursor-pointer p-1'
-                          : 'btn-default cursor-not-allowed'
-                      }`}
-                    >
+                  ) : (
+                    <button onClick={() => setExpanded(!expanded)} className='btn-default w-full'>
                       Extend
                     </button>
-                  </ToolTipNew>
-                </div>
-              ) : (
-                <ToolTipNew
-                  outerStyles='flex self-center'
-                  hideToolTip={isOnCorrectNetwork}
-                  toolTipText={'Please switch to the correct network to refund this deposit.'}
-                >
-                  <button
-                    onClick={!isOnCorrectNetwork ? addOrSwitchNetwork : () => setExpanded(!expanded)}
-                    className='btn-default w-full'
-                  >
-                    {!isOnCorrectNetwork ? 'Change Network' : 'Extend'}
-                  </button>
-                </ToolTipNew>
+                  )}
+                </>
               )}
-            </>
-          )}
-        </div>
+            </div>
+          </>
+        )}
+      </div>
+      <div className='pb-8'>
+        <ConnectButton nav={false} needsGithub={false} />
       </div>
     </div>
   );

--- a/components/RefundBounty/RefundPage.js
+++ b/components/RefundBounty/RefundPage.js
@@ -220,7 +220,6 @@ const RefundPage = ({ bounty, refreshBounty, internalMenu }) => {
                             status='refunded'
                             bounty={bounty}
                             refundBounty={refundBounty}
-                            account={account}
                           />
                         </div>
                       );

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -12,7 +12,7 @@ import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
 import StoreContext from '../../store/Store/StoreContext';
 // import axios from 'axios';
 
-const ConnectButton = ({ mobile }) => {
+const ConnectButton = () => {
   // Context
   const { chainId, error, account, safe } = useWeb3();
   const [ensName] = useEns(account);
@@ -41,7 +41,7 @@ const ConnectButton = ({ mobile }) => {
     const createJazzicon = async () => {
       if (account && iconWrapper.current) {
         iconWrapper.current.innerHTML = '';
-        iconWrapper.current.appendChild(jazzicon(mobile ? 52 : 26, parseInt(account.slice(2, 10), 16)));
+        iconWrapper.current.appendChild(jazzicon(26, parseInt(account.slice(2, 10), 16)));
       }
     };
     createJazzicon();

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -16,7 +16,7 @@ import useAuth from '../../hooks/useAuth';
 import ToolTipNew from '../Utils/ToolTipNew';
 // import axios from 'axios';
 
-const ConnectButton = ({ needsGithub, nav, tooltipAction }) => {
+const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut }) => {
   // Context
   const { chainId, error, account, safe } = useWeb3();
   const [ensName] = useEns(account);
@@ -96,7 +96,7 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction }) => {
   return (
     <>
       {needsGithub && !authState.isAuthenticated ? (
-        <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} />
+        <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} hideSignOut={hideSignOut} />
       ) : (
         <div>
           {account && isOnCorrectNetwork ? (

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -152,7 +152,7 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut }) => {
             >
               <button
                 onClick={openConnectModal}
-                className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d] whitespace-nowrap'
+                className='flex items-center btn-default mr-4 whitespace-nowrap'
                 disabled={isConnecting}
               >
                 {'Connect Wallet'}
@@ -166,10 +166,7 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut }) => {
               innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
               toolTipText={'Please switch to the correct network to fund this contract.'}
             >
-              <button
-                onClick={addOrSwitchNetwork}
-                className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d] whitespace-nowrap'
-              >
+              <button onClick={addOrSwitchNetwork} className='flex items-center btn-default mr-4 whitespace-nowrap'>
                 Use {chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network
               </button>
             </ToolTipNew>

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -12,12 +12,15 @@ import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
 import StoreContext from '../../store/Store/StoreContext';
 import AuthButton from '../Authentication/AuthButton';
 import { useRouter } from 'next/router';
+import useAuth from '../../hooks/useAuth';
+import ToolTipNew from '../Utils/ToolTipNew';
 // import axios from 'axios';
 
-const ConnectButton = ({ needsGithub, isAuthenticated }) => {
+const ConnectButton = ({ needsGithub, nav, tooltipAction }) => {
   // Context
   const { chainId, error, account, safe } = useWeb3();
   const [ensName] = useEns(account);
+  const [authState] = useAuth();
   const router = useRouter();
   const [appState, dispatch] = useContext(StoreContext);
   const { walletConnectModal } = appState;
@@ -92,51 +95,61 @@ const ConnectButton = ({ needsGithub, isAuthenticated }) => {
   // Render
   return (
     <>
-      {needsGithub && !isAuthenticated ? (
+      {needsGithub && !authState.isAuthenticated ? (
         <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} />
       ) : (
         <div>
           {account && isOnCorrectNetwork ? (
-            <div>
-              <button
-                disabled={isConnecting}
-                ref={buttonRef}
-                onClick={() => {
-                  setShowModal(!showModal);
-                }}
-                className='group flex items-center gap-x-1 h-12 whitespace-nowrap py-1 px-3 font-semibold cursor-pointer'
-              >
-                <span
-                  className='border border-[#8b949e] rounded-full h-7 py-pxt group-hover:border-opacity-70'
-                  ref={iconWrapper}
-                ></span>
-                <span className='md:group-hover:opacity-70'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    className='h-3 w-3'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                    stroke='white'
-                    strokeWidth='3'
+            <>
+              {nav ? (
+                <div>
+                  <button
+                    disabled={isConnecting}
+                    ref={buttonRef}
+                    onClick={() => {
+                      setShowModal(!showModal);
+                    }}
+                    className='group flex items-center gap-x-1 h-12 whitespace-nowrap py-1 px-3 font-semibold cursor-pointer'
                   >
-                    <path strokeLinecap='round' strokeLinejoin='round' d='M19 9l-7 7-7-7' />
-                  </svg>
-                </span>
-              </button>
+                    <span
+                      className='border border-[#8b949e] rounded-full h-7 py-pxt group-hover:border-opacity-70'
+                      ref={iconWrapper}
+                    ></span>
+                    <span className='md:group-hover:opacity-70'>
+                      <svg
+                        xmlns='http://www.w3.org/2000/svg'
+                        className='h-3 w-3'
+                        fill='none'
+                        viewBox='0 0 24 24'
+                        stroke='white'
+                        strokeWidth='3'
+                      >
+                        <path strokeLinecap='round' strokeLinejoin='round' d='M19 9l-7 7-7-7' />
+                      </svg>
+                    </span>
+                  </button>
 
-              {showModal && (
-                <AccountModal
-                  domRef={modalRef}
-                  account={account}
-                  ensName={ensName}
-                  chainId={chainId}
-                  setIsConnecting={setIsConnecting}
-                  isSafeApp={safe}
-                />
-              )}
-            </div>
+                  {showModal && (
+                    <AccountModal
+                      domRef={modalRef}
+                      account={account}
+                      ensName={ensName}
+                      chainId={chainId}
+                      setIsConnecting={setIsConnecting}
+                      isSafeApp={safe}
+                    />
+                  )}
+                </div>
+              ) : null}
+            </>
           ) : isOnCorrectNetwork ? (
-            <div>
+            <ToolTipNew
+              relativePosition={'left-0'}
+              outerStyles={'-top-1 '}
+              groupStyles={'w-min'}
+              innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
+              toolTipText={`Connect your wallet to ${tooltipAction}`}
+            >
               <button
                 onClick={openConnectModal}
                 className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d] whitespace-nowrap'
@@ -144,14 +157,22 @@ const ConnectButton = ({ needsGithub, isAuthenticated }) => {
               >
                 {'Connect Wallet'}
               </button>
-            </div>
+            </ToolTipNew>
           ) : (
-            <button
-              onClick={addOrSwitchNetwork}
-              className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d]'
+            <ToolTipNew
+              relativePosition={'left-0'}
+              outerStyles={'-top-1 '}
+              groupStyles={'w-min'}
+              innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
+              toolTipText={'Please switch to the correct network to fund this contract.'}
             >
-              Use {chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network
-            </button>
+              <button
+                onClick={addOrSwitchNetwork}
+                className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d] whitespace-nowrap'
+              >
+                Use {chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network
+              </button>
+            </ToolTipNew>
           )}
           {walletConnectModal && <ConnectModal closeModal={closeModal} setShowModal={setShowModal} />}
         </div>

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -16,7 +16,7 @@ import useAuth from '../../hooks/useAuth';
 import ToolTipNew from '../Utils/ToolTipNew';
 // import axios from 'axios';
 
-const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut }) => {
+const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut, centerStyles }) => {
   // Context
   const { chainId, error, account, safe } = useWeb3();
   const [ensName] = useEns(account);
@@ -95,7 +95,7 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut }) => {
   // Render
   return (
     <>
-      {needsGithub && !authState.isAuthenticated ? (
+      {needsGithub && authState.isAuthenticated ? (
         <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} hideSignOut={hideSignOut} />
       ) : (
         <div>
@@ -144,15 +144,15 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut }) => {
             </>
           ) : isOnCorrectNetwork ? (
             <ToolTipNew
-              relativePosition={'left-0'}
+              relativePosition={centerStyles ? '' : 'left-0'}
               outerStyles={'-top-1 '}
-              groupStyles={'w-min'}
+              groupStyles={centerStyles ? '' : 'w-min'}
               innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
               toolTipText={`Connect your wallet to ${tooltipAction}`}
             >
               <button
                 onClick={openConnectModal}
-                className='flex items-center btn-default mr-4 whitespace-nowrap'
+                className='flex w-full items-center justify-center btn-default mr-4 whitespace-nowrap'
                 disabled={isConnecting}
               >
                 {'Connect Wallet'}
@@ -160,13 +160,16 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut }) => {
             </ToolTipNew>
           ) : (
             <ToolTipNew
-              relativePosition={'left-0'}
+              relativePosition={centerStyles ? '' : 'left-0'}
               outerStyles={'-top-1 '}
-              groupStyles={'w-min'}
+              groupStyles={centerStyles ? '' : 'w-min'}
               innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
               toolTipText={'Please switch to the correct network to fund this contract.'}
             >
-              <button onClick={addOrSwitchNetwork} className='flex items-center btn-default mr-4 whitespace-nowrap'>
+              <button
+                onClick={addOrSwitchNetwork}
+                className='flex w-full items-center justify-center btn-default mr-4 whitespace-nowrap'
+              >
                 Use {chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network
               </button>
             </ToolTipNew>

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -10,12 +10,15 @@ import ConnectModal from './ConnectModal';
 import useEns from '../../hooks/useENS';
 import useIsOnCorrectNetwork from '../../hooks/useIsOnCorrectNetwork';
 import StoreContext from '../../store/Store/StoreContext';
+import AuthButton from '../Authentication/AuthButton';
+import { useRouter } from 'next/router';
 // import axios from 'axios';
 
-const ConnectButton = () => {
+const ConnectButton = ({ needsGithub, isAuthenticated }) => {
   // Context
   const { chainId, error, account, safe } = useWeb3();
   const [ensName] = useEns(account);
+  const router = useRouter();
   const [appState, dispatch] = useContext(StoreContext);
   const { walletConnectModal } = appState;
 
@@ -88,66 +91,72 @@ const ConnectButton = () => {
 
   // Render
   return (
-    <div>
-      {account && isOnCorrectNetwork ? (
-        <div>
-          <button
-            disabled={isConnecting}
-            ref={buttonRef}
-            onClick={() => {
-              setShowModal(!showModal);
-            }}
-            className='group flex items-center gap-x-1 h-12 whitespace-nowrap py-1 px-3 font-semibold cursor-pointer'
-          >
-            <span
-              className='border border-[#8b949e] rounded-full h-7 py-pxt group-hover:border-opacity-70'
-              ref={iconWrapper}
-            ></span>
-            <span className='md:group-hover:opacity-70'>
-              <svg
-                xmlns='http://www.w3.org/2000/svg'
-                className='h-3 w-3'
-                fill='none'
-                viewBox='0 0 24 24'
-                stroke='white'
-                strokeWidth='3'
-              >
-                <path strokeLinecap='round' strokeLinejoin='round' d='M19 9l-7 7-7-7' />
-              </svg>
-            </span>
-          </button>
-
-          {showModal && (
-            <AccountModal
-              domRef={modalRef}
-              account={account}
-              ensName={ensName}
-              chainId={chainId}
-              setIsConnecting={setIsConnecting}
-              isSafeApp={safe}
-            />
-          )}
-        </div>
-      ) : isOnCorrectNetwork ? (
-        <div>
-          <button
-            onClick={openConnectModal}
-            className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d] whitespace-nowrap'
-            disabled={isConnecting}
-          >
-            {'Connect Wallet'}
-          </button>
-        </div>
+    <>
+      {needsGithub && !isAuthenticated ? (
+        <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} />
       ) : (
-        <button
-          onClick={addOrSwitchNetwork}
-          className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d]'
-        >
-          Use {chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network
-        </button>
+        <div>
+          {account && isOnCorrectNetwork ? (
+            <div>
+              <button
+                disabled={isConnecting}
+                ref={buttonRef}
+                onClick={() => {
+                  setShowModal(!showModal);
+                }}
+                className='group flex items-center gap-x-1 h-12 whitespace-nowrap py-1 px-3 font-semibold cursor-pointer'
+              >
+                <span
+                  className='border border-[#8b949e] rounded-full h-7 py-pxt group-hover:border-opacity-70'
+                  ref={iconWrapper}
+                ></span>
+                <span className='md:group-hover:opacity-70'>
+                  <svg
+                    xmlns='http://www.w3.org/2000/svg'
+                    className='h-3 w-3'
+                    fill='none'
+                    viewBox='0 0 24 24'
+                    stroke='white'
+                    strokeWidth='3'
+                  >
+                    <path strokeLinecap='round' strokeLinejoin='round' d='M19 9l-7 7-7-7' />
+                  </svg>
+                </span>
+              </button>
+
+              {showModal && (
+                <AccountModal
+                  domRef={modalRef}
+                  account={account}
+                  ensName={ensName}
+                  chainId={chainId}
+                  setIsConnecting={setIsConnecting}
+                  isSafeApp={safe}
+                />
+              )}
+            </div>
+          ) : isOnCorrectNetwork ? (
+            <div>
+              <button
+                onClick={openConnectModal}
+                className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d] whitespace-nowrap'
+                disabled={isConnecting}
+              >
+                {'Connect Wallet'}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={addOrSwitchNetwork}
+              className='flex items-center btn-default mr-4 hover:border-[#8b949e] hover:bg-[#30363d]'
+            >
+              Use {chainIdDeployEnvMap[process.env.NEXT_PUBLIC_DEPLOY_ENV]['networkName']} Network
+            </button>
+          )}
+          {walletConnectModal && <ConnectModal closeModal={closeModal} setShowModal={setShowModal} />}
+        </div>
       )}
-      {walletConnectModal && <ConnectModal closeModal={closeModal} setShowModal={setShowModal} />}
-    </div>
+    </>
   );
 };
 

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -95,7 +95,7 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction, hideSignOut, centerSty
   // Render
   return (
     <>
-      {needsGithub && authState.isAuthenticated ? (
+      {needsGithub && !authState.isAuthenticated ? (
         <AuthButton redirectUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/` + router.asPath} hideSignOut={hideSignOut} />
       ) : (
         <div>


### PR DESCRIPTION
closes #1024 => in Navigation, only show "connect wallet" button if signed in with GitHub (related to #1023)
closes #1026 => now (hopefully all) buttons that need the "Connect Wallet" or "Use <right> Network" or "Sign in" logic use the ConnectButton component. We can easily determine which buttons need the Github sign in or not with the prop "needsGithub", and we can change the logic of our flow centrally when we need to.

Still needs to add tests (existing ones where modified already)
 