### PR TITLE
Minor fixes

### DIFF
--- a/components/Utils/Jazzicon.js
+++ b/components/Utils/Jazzicon.js
@@ -1,7 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import jazzicon from '@metamask/jazzicon';
 import ToolTipNew from './ToolTipNew';
-import Link from 'next/link';
 
 const Jazzicon = ({ address, size, tooltipPosition, name }) => {
   const iconWrapper = useRef();
@@ -12,13 +11,11 @@ const Jazzicon = ({ address, size, tooltipPosition, name }) => {
     }
   }, [address]);
   return (
-    <Link href={`${process.env.NEXT_PUBLIC_BASE_URL}/user/${address}`}>
-      <div data-testid='link' className={`cursor-pointer ${!address && 'w-9 h-9 mr-px'}`}>
-        <ToolTipNew toolTipText={name || address} outerStyles={'relative bottom-2'} relativePosition={tooltipPosition}>
-          <div ref={iconWrapper}>{address}</div>
-        </ToolTipNew>
-      </div>
-    </Link>
+    <div data-testid='link' className={`cursor-pointer ${!address && 'w-9 h-9 mr-px'}`}>
+      <ToolTipNew toolTipText={name || address} outerStyles={'relative bottom-2'} relativePosition={tooltipPosition}>
+        <div ref={iconWrapper}>{address}</div>
+      </ToolTipNew>
+    </div>
   );
 };
 export default Jazzicon;

--- a/components/Utils/SubMenu.js
+++ b/components/Utils/SubMenu.js
@@ -3,7 +3,7 @@ import React from 'react';
 const SubMenu = ({ updatePage, internalMenu, items, styles, colour, vertical }) => {
   return (
     <div
-      className={`px-2 ${!vertical && 'sm:px-8'} text-primary  w-full flex ${
+      className={`px-2 ${!vertical ? 'sm:px-8' : 'px-0'} text-primary  w-full flex ${
         vertical ? 'flex-col gap-2' : 'h-12 overflow-x-auto border-web-gray border-b items-center'
       }  gap-x-1 md:gap-x-4 relative ${styles} `}
     >
@@ -12,27 +12,27 @@ const SubMenu = ({ updatePage, internalMenu, items, styles, colour, vertical }) 
           <button
             type='button'
             onClick={() => updatePage(item.name)}
-            className={`cursor-pointerpx-1 flex gap-1 sm:gap-2 items-center text-sm hover:bg-inactive-gray leading-5 py-1 hover:bg-active-gray rounded-sm justify-center w-fit ${
+            className={`${
+              vertical && 'pl-2'
+            } cursor-pointer px-1 flex gap-1 sm:gap-2 items-center text-sm hover:bg-inactive-gray leading-5 py-1 hover:bg-active-gray rounded-sm justify-center w-fit ${
               internalMenu === item.name &&
-              ` ${
-                vertical
-                  ? 'after:h-5 after:left-0 after:w-0.5 after:absolute'
-                  : 'after:w-20 after:bottom-0 after:h-0.5 after:absolute'
-              } `
+              ` ${vertical && 'after:h-5 after:left-0 after:w-0.5 after:absolute after:bg-link-colour'} `
             }`}
           >
             {item.Svg && <item.Svg />}
             <span className='whitespace-nowrap'>{item.name}</span>
           </button>
-          <div
-            className={`absolute w-full  top-9 border-t ${
-              internalMenu === item.name
-                ? colour === 'rust'
-                  ? 'border-rust '
-                  : 'border-link-colour'
-                : 'border-transparent'
-            }`}
-          ></div>
+          {!vertical && (
+            <div
+              className={`absolute w-full  top-9 border ${
+                internalMenu === item.name
+                  ? colour === 'rust'
+                    ? 'border-rust bg-rust'
+                    : 'border-link-colour bg-link-colour'
+                  : 'border-transparent'
+              }`}
+            ></div>
+          )}
         </li>
       ))}
     </div>


### PR DESCRIPTION
- broken link for component Jazzicon since user address is no longer a link => just removed the link since normally from now on the Github icon / link should show instead. Long term solution depends on discussion #1023 and whether funders etc. can act without Github login (but I guess we'd agree they need to login with Github, in which case the Jazzicon would only be relevant for older actions performed without a Github login).
- fixing vertical submenu, and making submenu coloured bar a bit thicker again



![image](https://user-images.githubusercontent.com/75732239/206456404-9e03263b-f971-4e6b-9396-520a80cc6a79.png)
