### PR TITLE
Add username update to profile

### DIFF
--- a/components/User/AboutFreelancer.js
+++ b/components/User/AboutFreelancer.js
@@ -23,6 +23,7 @@ import Subscribe from '../Utils/Subscribe';
 import GithubConnection from './OverviewTab/GithubConnection';
 import useWeb3 from '../../hooks/useWeb3';
 import AuthContext from '../../store/AuthStore/AuthContext';
+import Username from './OverviewTab/Username';
 
 const AboutFreelancer = ({ user, organizations, starredOrganizations, showWatched, watchedBounties }) => {
   const { payoutTokenBalances, payouts } = user;
@@ -141,6 +142,7 @@ const AboutFreelancer = ({ user, organizations, starredOrganizations, showWatche
           <div className='flex flex-col flex-1 lg:pl-20 '>
             {internalMenu == 'Overview' && (
               <div className=''>
+                <Username user={user} />
                 <AboutTitle ensName={ensName} account={account} githubUser={githubUser} />
 
                 <UserHistory organizations={organizations} payouts={payouts} />

--- a/components/User/OverviewTab/Username.js
+++ b/components/User/OverviewTab/Username.js
@@ -1,0 +1,89 @@
+// Third party
+import React, { useState, useContext } from 'react';
+import Pencil from '../../svg/pencil';
+import ToolTipNew from '../../Utils/ToolTipNew';
+import StoreContext from '../../../store/Store/StoreContext';
+import AuthContext from '../../../store/AuthStore/AuthContext';
+// Custom
+
+const Username = ({ user }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(user.username);
+  const [localUsername, setLocalUsername] = useState(user.username);
+  const [appState] = useContext(StoreContext);
+  const [validUsername, setValidUsername] = useState(false);
+  const [authState] = useContext(AuthContext);
+  const { accountData } = appState;
+  const loggedId = accountData?.id;
+  const isOwner = authState.isAuthenticated && loggedId == user.id;
+
+  // VALIDUSERNAME CHECK
+  // Make sure also update when logged in with email (and same for ediatble socials)
+
+  const handleEdit = () => {
+    if (isOwner) {
+      setIsEditing(true);
+    }
+  };
+  const handleSave = async () => {
+    try {
+      const githubId = user.github;
+      const { updateUser } = await appState.openQPrismaClient.updateUser({ username: inputValue, github: githubId });
+      if (updateUser) {
+        setLocalUsername(inputValue);
+        setIsEditing(false);
+      }
+    } catch (err) {
+      setIsEditing(false);
+    }
+  };
+  const handleKeypress = (e) => {
+    //it triggers by pressing the enter key
+    if (e.key === 'Enter') {
+      handleSave(inputValue);
+    }
+  };
+  const handleInputChange = (e) => {
+    const { value } = e.target;
+    setInputValue(value);
+    setValidUsername(true); // make condition here
+  };
+
+  return (
+    <div className='px-8 py-6 gap-6 flex flex-wrap items-stretch w-full font-semibold text-lg'>
+      <div className='flex-1 flex-row'>
+        <div className='pb-2'>Username</div>
+        {!isEditing ? (
+          <div className='flex w-fit items-center gap-4'>
+            <div className='font-normal flex-1'>{localUsername}</div>
+            {isOwner && (
+              <button className='h-67' onClick={handleEdit}>
+                <Pencil className={'fill-muted'} />
+              </button>
+            )}
+          </div>
+        ) : isOwner ? (
+          <div className='flex w-36 items-center gap-4'>
+            <input
+              onChange={handleInputChange}
+              onKeyDown={handleKeypress}
+              value={inputValue}
+              className='input-field-big pl-4 bg-transparent cursor-auto focus-within:outline-none'
+            />
+            <ToolTipNew hideToolTip={validUsername} toolTipText={'Username is not valid'}>
+              <button
+                disabled={!validUsername}
+                className={validUsername ? 'btn-primary text-sm' : 'btn-default text-sm cursor-not-allowed'}
+                onClick={() => handleSave(inputValue)}
+              >
+                Update
+              </button>
+            </ToolTipNew>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default Username;

--- a/pages/user/[userId].js
+++ b/pages/user/[userId].js
@@ -57,7 +57,7 @@ const userId = ({ user, organizations, renderError }) => {
 
   return (
     <div className=' gap-4 justify-center pt-6'>
-      {user?.email || user?.github ? (
+      {user?.id ? (
         <AboutFreelancer
           showWatched={user.id === signedAccount}
           starredOrganizations={starredOrganizations}
@@ -79,6 +79,7 @@ export const getServerSideProps = async (context) => {
   const { github_oauth_token_unsigned } = cookies;
   const logger = new Logger();
   const oauthToken = github_oauth_token_unsigned ? github_oauth_token_unsigned : null;
+  const emailAuth = true;
   githubRepository.instance.setGraphqlHeaders(oauthToken);
 
   let userId = context.params.userId;
@@ -107,7 +108,11 @@ export const getServerSideProps = async (context) => {
 
   try {
     // 1. We fetch the API user using the userId we get from the URL
-    userOffChainData = await openQPrismaClient.instance.getPublicUserById(userId);
+    if (emailAuth) {
+      userOffChainData = await openQPrismaClient.instance.getPublicUserById(userId);
+    } else {
+      userOffChainData = await openQPrismaClient.instance.getUser(userId);
+    }
     if (!userOffChainData) {
       // This is where we should throw a 404
       return { props: { renderError: `User with id ${userId} not found.` } };

--- a/services/openq-api/OpenQPrismaClient.js
+++ b/services/openq-api/OpenQPrismaClient.js
@@ -389,6 +389,7 @@ class OpenQPrismaClient {
         });
         resolve(result.data.user);
       } catch (e) {
+        console.log(e);
         reject(e);
       }
     });

--- a/services/openq-api/graphql/query.js
+++ b/services/openq-api/graphql/query.js
@@ -77,6 +77,7 @@ export const GET_USER_BY_ID = gql`
   query ($id: String!) {
     user(id: $id) {
       github
+      username
       discord
       twitter
       devRoles
@@ -93,6 +94,7 @@ export const GET_USER = gql`
     user(id: $id, email: $email, github: $github) {
       id
       github
+      username
       discord
       twitter
       devRoles
@@ -112,7 +114,7 @@ export const GET_PRIVATE_USER = gql`
       github
       email
       company
-      email
+      username
       city
       streetAddress
       country
@@ -152,6 +154,7 @@ export const GET_USERS = gql`
         discord
         twitter
         email
+        username
         starredOrganizationIds
       }
     }
@@ -246,6 +249,7 @@ export const UPDATE_USER = gql`
     $id: String
     $email: String
     $github: String
+    $username: String
     $company: String
     $city: String
     $streetAddress: String
@@ -270,6 +274,7 @@ export const UPDATE_USER = gql`
       id: $id
       email: $email
       github: $github
+      username: $username
       company: $company
       city: $city
       streetAddress: $streetAddress
@@ -293,7 +298,7 @@ export const UPDATE_USER = gql`
       github
       email
       company
-      email
+      username
       city
       streetAddress
       country


### PR DESCRIPTION
Requires this PR first: https://github.com/OpenQDev/OpenQ-API/pull/40

Adds Username to be edited on Profile page

Questions that remain open:
- updating username (and other socials / info) with the email auth (currently only github auth)
- checking whether other users have the same username before accepting it
- potentially checking for non-desirable usernames?


![image](https://user-images.githubusercontent.com/75732239/207111690-797d459f-ef2e-4c5f-a513-e147b3c17424.png)
