### PR TITLE
AuthState fix

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -16,15 +16,16 @@ const useAuth = (state) => {
       appState.authService
         .checkAuth()
         .then((data) => {
+          console.log('data', data);
           if (!didCancel) {
             setAuthState({
               type: 'UPDATE_IS_AUTHENTICATED',
               payload: {
-                isAuthenticated: data.payload.isAuthenticated,
-                avatarUrl: data.payload.avatarUrl,
-                login: data.payload.login,
-                githubId: data.payload.githubId,
-                email: data.payload.email,
+                isAuthenticated: data.isAuthenticated,
+                avatarUrl: data.avatar_url,
+                login: data.login,
+                githubId: data.node_id,
+                email: data.email,
               },
             });
           }

--- a/pages/auth/github.js
+++ b/pages/auth/github.js
@@ -2,11 +2,13 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useRouter } from 'next/router';
 import StoreContext from '../../store/Store/StoreContext';
+import AuthContext from '../../store/AuthStore/AuthContext';
 
 function GitHubAuth() {
   const router = useRouter();
   const [, setAuthCode] = useState('NO AUTH CODE');
   const [appState] = useContext(StoreContext);
+  const [, dispatch] = useContext(AuthContext);
   const [userId, setUserId] = useState(null);
 
   useEffect(() => {
@@ -35,12 +37,12 @@ function GitHubAuth() {
           try {
             // Get the user's github id from checkAuth
             const result = await appState.authService.checkAuth();
+            dispatch(result);
             const github = result.payload.githubId;
 
             // Get the user's full profile from the database
             const fullApiUser = await appState.openQPrismaClient.getPublicUser(github);
 
-            console.log(fullApiUser, 'fullApiUser');
             const isNewUser = !fullApiUser;
 
             if (isNewUser) {

--- a/pages/auth/github.js
+++ b/pages/auth/github.js
@@ -37,8 +37,12 @@ function GitHubAuth() {
           try {
             // Get the user's github id from checkAuth
             const result = await appState.authService.checkAuth();
-            dispatch(result);
-            const github = result.payload.githubId;
+            const { isAuthenticated, avatar_url, login, node_id, email } = result;
+            dispatch({
+              type: 'UPDATE_IS_AUTHENTICATED',
+              payload: { isAuthenticated, avatarUrl: avatar_url, login, githubId: node_id, email },
+            });
+            const github = node_id;
 
             // Get the user's full profile from the database
             const fullApiUser = await appState.openQPrismaClient.getPublicUser(github);
@@ -66,6 +70,7 @@ function GitHubAuth() {
   };
 
   useEffect(() => {
+    console.log(userId);
     if (userId) {
       router.push(`${process.env.NEXT_PUBLIC_BASE_URL}/user/${userId}`);
     }

--- a/services/auth/AuthService.js
+++ b/services/auth/AuthService.js
@@ -19,11 +19,7 @@ class AuthService {
     return new Promise(async (resolve, reject) => {
       try {
         const response = await axios.get(`${process.env.NEXT_PUBLIC_AUTH_URL}/checkAuth`, { withCredentials: true });
-        const { isAuthenticated, avatar_url, login, email } = response.data;
-        resolve({
-          type: 'UPDATE_IS_AUTHENTICATED',
-          payload: { isAuthenticated, avatarUrl: avatar_url, login, githubId: response.data.node_id, email },
-        });
+        resolve(response.data);
       } catch (error) {
         reject(error);
       }

--- a/store/Store/StoreReducer.js
+++ b/store/Store/StoreReducer.js
@@ -5,11 +5,11 @@ const StoreReducer = (state, action) => {
         ...state,
         accountData: action.payload || {},
       };
-    /*     case 'BOUNTY_MINTED':
+    case 'BOUNTY_MINTED':
       return {
         ...state,
         bountyMinted: action.payload,
-      }; */
+      };
     case 'UPDATE_IS_AUTHENTICATED':
       return {
         ...state,
@@ -40,23 +40,23 @@ const StoreReducer = (state, action) => {
         ...state,
         needsReload: action.payload,
       };
-    /* case 'RELOAD_NOW':
+    case 'RELOAD_NOW':
       return {
         ...state,
         reloadNow: action.payload,
-      }; */
+      };
     case 'CONNECT_WALLET': {
       return {
         ...state,
         walletConnectModal: action.payload,
       };
     }
-    /* case 'UPDATE_ACCOUNT_DATA': {
+    case 'UPDATE_ACCOUNT_DATA': {
       return {
         ...state,
         accountData: action.payload,
       };
-    } */
+    }
     default:
       return state;
   }

--- a/store/Store/StoreReducer.js
+++ b/store/Store/StoreReducer.js
@@ -5,17 +5,17 @@ const StoreReducer = (state, action) => {
         ...state,
         accountData: action.payload || {},
       };
-    case 'BOUNTY_MINTED':
+    /*     case 'BOUNTY_MINTED':
       return {
         ...state,
         bountyMinted: action.payload,
-      };
+      }; */
     case 'UPDATE_IS_AUTHENTICATED':
       return {
         ...state,
         isAuthenticated: action.payload,
       };
-    case 'UPDATE_ADDRESS':
+    /*     case 'UPDATE_ADDRESS':
       return {
         ...state,
         publicAddress: action.payload,
@@ -34,29 +34,29 @@ const StoreReducer = (state, action) => {
       return {
         ...state,
         signedAccount: action.payload,
-      };
+      }; */
     case 'UPDATE_RELOAD':
       return {
         ...state,
         needsReload: action.payload,
       };
-    case 'RELOAD_NOW':
+    /* case 'RELOAD_NOW':
       return {
         ...state,
         reloadNow: action.payload,
-      };
+      }; */
     case 'CONNECT_WALLET': {
       return {
         ...state,
         walletConnectModal: action.payload,
       };
     }
-    case 'UPDATE_ACCOUNT_DATA': {
+    /* case 'UPDATE_ACCOUNT_DATA': {
       return {
         ...state,
         accountData: action.payload,
       };
-    }
+    } */
     default:
       return state;
   }


### PR DESCRIPTION
- closes #1109: dispatching payload to AuthContext for Github login - profile previously needed reload to show authenticated mode
- also commenting out logic that seems unused in the StoreReducer

Would love a review of the AuthContext vs. StoreContext logic (for my better understanding) before merging 