### PR TITLE
Use local linter in git hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 
 echo "Linting to make sure your code is ✨ spotless ✨ which I'm sure it is..."
 echo "If any linting errors are found, please fix them, git add ., and re-commit 🤠."
-eslint --fix .
+yarn run lint:fix

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",
+		"lint:fix": "next lint --fix",
 		"test": "TZ=UTC jest --watch --runInBand",
 		"test:cicd": "TZ=UTC jest --runInBand",
 		"gen": "node services/ethers/mocks/abiToJavascriptClass.js",


### PR DESCRIPTION
When eslint isn't installed globally, the commit hook doesn't work. Changed it to use the local version via yarn.