### PR TITLE
Fix Message for Graph Indexing

### DIFF
--- a/components/Utils/ActionBubble.js
+++ b/components/Utils/ActionBubble.js
@@ -184,7 +184,7 @@ const ActionBubble = ({ bounty, action }) => {
       ) : (
         <Jazzicon tooltipPosition={'-left-2'} size={36} address={address} name={name} />
       )}
-      <div className='w-full bg-nav-bg flex-0 rounded-sm overflow-hidden ml-4 border-web-gray border-b before:w-2 before:h-2 before:bg-nav-bg before:absolute before:left-12 before:top-[34px] before:border-b  before:border-l before:border-web-gray before:rotate-45  border'>
+      <div className={` w-full bg-nav-bg flex-0 rounded-sm overflow-hidden ml-4 border-web-gray border-b ${!bounty.issuer ? null : 'before:w-2 before:h-2 before:bg-nav-bg before:absolute before:left-12 before:top-[34px] before:border-b  before:border-l before:border-web-gray before:rotate-45'}  border`}>
         <div className={` w-full pl-3 ${!action ? 'border-web-gray' : null} flex justify-between`}>
           <span className='py-2'>
             <span data-testid='actionTitle'>{titlePartOne}</span>


### PR DESCRIPTION
### Sumary
Remove the `:before` when `bounty.issuer` is true.
Here is a working image.
![Fixed](https://user-images.githubusercontent.com/48979376/214494814-ddbaa8c9-1b92-4f43-9794-d5ac3a8f60ba.PNG)

### Changelog
Fixed issue #1227 
