### PR TITLE
Fixing: Bounty just minted issues

### DIFF
--- a/components/MintBounty/MintBountyModal/MintBountyInputIssue/MintBountyInputIssue.js
+++ b/components/MintBounty/MintBountyModal/MintBountyInputIssue/MintBountyInputIssue.js
@@ -42,7 +42,7 @@ const MintBountyInputIssue = () => {
         const issueData = await fetchIssue();
         if (issueData) {
           try {
-            let bounty = await appState.openQSubgraphClient.getBountyByGithubId(issueData.id);
+            let bounty = await appState.openQSubgraphClient.getBountyByGithubId(issueData.id, 'no-cache');
             if (closed === false && bounty?.status == '1' && didCancel) {
               setClosed(true);
             }

--- a/pages/contract/[id]/[address].js
+++ b/pages/contract/[id]/[address].js
@@ -61,7 +61,7 @@ const address = ({ address, mergedBounty, renderError }) => {
 
   // State
   const [error] = useState(renderError);
-  const [internalMenu, setInternalMenu] = useState();
+  const [internalMenu, setInternalMenu] = useState('View');
   const [, setJustMinted] = useState();
 
   // Refs
@@ -226,8 +226,8 @@ const address = ({ address, mergedBounty, renderError }) => {
                 colour='rust'
                 items={[
                   { name: 'View', Svg: Telescope },
-                  { name: 'Fund', Svg: Add },
-                  { name: 'Refund', Svg: Subtract },
+                  { name: bounty.issuer && 'Fund', Svg: bounty.issuer && Add },
+                  { name: bounty.issuer && 'Refund', Svg: bounty.issuer && Subtract },
                   ...submissions,
                   ...claim,
                   ...claimOverView,

--- a/services/subgraph/OpenQSubgraphClient.js
+++ b/services/subgraph/OpenQSubgraphClient.js
@@ -88,12 +88,13 @@ class OpenQSubgraphClient {
     return promise;
   }
 
-  async getBountyByGithubId(id) {
+  async getBountyByGithubId(id, fetchPolicy = 'cache-first') {
     const promise = new Promise(async (resolve, reject) => {
       try {
         const result = await this.client.query({
           query: GET_BOUNTY_BY_ID,
           variables: { id },
+          fetchPolicy,
         });
         resolve(result.data.bounties[0] ? result.data.bounties[0] : null);
       } catch (e) {


### PR DESCRIPTION
closes #1241 

- fetching issue info with no cache to make sure "bounty already minted" shows when trying to mint
- hides all tabs except View when there is no info yet from the Subgraph for the contract page

![image](https://user-images.githubusercontent.com/75732239/216369866-54430bec-3c0e-4f9e-9ce8-38b7ccb04250.png)
