### PR TITLE
Misc. fixes

### DIFF
--- a/components/Bounty/BountyHeading/index.js
+++ b/components/Bounty/BountyHeading/index.js
@@ -17,8 +17,8 @@ const BountyHeading = ({
   refreshGithubBounty,
   refreshBounty,
   setInternalMenu,
+  internalMenu,
   split,
-  price,
   claimReqsCompleted,
 }) => {
   const [appState] = useContext(StoreContext);
@@ -53,9 +53,10 @@ const BountyHeading = ({
               tooltipStyle={'-right-2'}
               refreshBounty={refreshBounty}
               setInternalMenu={setInternalMenu}
+              internalMenu={internalMenu}
               claimable={claimReqsCompleted}
               split={split}
-              price={price}
+              bountyHeading={true}
             />
           )}
         </div>

--- a/components/Claim/ClaimPage/ClaimButton/index.js
+++ b/components/Claim/ClaimPage/ClaimButton/index.js
@@ -24,10 +24,11 @@ const ClaimButton = ({
   tooltipStyle,
   refreshBounty,
   setInternalMenu,
+  internalMenu,
   split,
-  price,
   setJustClaimed,
   claimable,
+  bountyHeading
 }) => {
   const { url } = bounty;
   const { account, library } = useWeb3();
@@ -45,6 +46,8 @@ const ClaimButton = ({
 
   const budgetValues = useDisplayValue(bounty, appState.utils.formatter.format, 'budget');
   const budget = budgetValues?.value;
+  const actualValues = useDisplayValue(bounty, appState.utils.formatter.format, 'actual');
+  const price = actualValues?.value;
   const canClaim = isEveryValueNotNull(claimable);
 
   const getRequiredText = (claimable) => {
@@ -55,13 +58,11 @@ const ClaimButton = ({
     invoice = claimable?.invoice ?? null;
     switch (null) {
       case githubHasWallet:
-        return 'You must have a wallet connected to your GitHub account to claim this bounty.';
+        return 'You must first associate a wallet to your GitHub account to claim this bounty.';
       case kyc:
         return 'You must complete KYC to claim this bounty.';
-
       case w8Form:
         return 'You must complete a W8 form to claim this bounty.';
-
       case invoice:
         return 'You must complete an invoice to claim this bounty.';
       default:
@@ -176,7 +177,6 @@ const ClaimButton = ({
       }
     }
   };
-
   return (
     <>
       {account && isOnCorrectNetwork && authState.isAuthenticated && (
@@ -195,11 +195,12 @@ const ClaimButton = ({
             type='submit'
             className={
               price >= budget && price > 0 && canClaim
-                ? 'btn-primary cursor-pointer w-fit'
-                : 'btn-default cursor-not-allowed'
+                ? 'btn-primary cursor-pointer w-fit' :
+                internalMenu == 'Claim' || !bountyHeading ? 'btn-default cursor-not-allowed'
+                  : 'btn-default'
             }
-            disabled={!(price >= budget && price > 0 && canClaim)}
-            onClick={() => setShowClaimLoadingModal(true)}
+            disabled={!(price >= budget && price > 0 && canClaim) && !bountyHeading}
+            onClick={bountyHeading ? () => setInternalMenu('Claim') : () => setShowClaimLoadingModal(true)}
           >
             <div className='flex gap-2 items-center'>
               {' '}

--- a/components/Claim/ClaimPage/KycRequirement/index.js
+++ b/components/Claim/ClaimPage/KycRequirement/index.js
@@ -31,7 +31,7 @@ const KycRequirement = ({ setKycVerified }) => {
   }, [failResponse, successResponse]);
   useEffect(() => {
     // chainId to 80001 if tested on Mumbai
-    if (account && chainId == 137 ) hasKYC();
+    if (account && chainId == 137) hasKYC();
   }, [chainId, account]);
   const onOpenSDK = useCallback(async () => {
     try {
@@ -76,12 +76,13 @@ const KycRequirement = ({ setKycVerified }) => {
       <h4 className='flex content-center items-center gap-2 border-b border-gray-700 pb-2'>
         <Image src='/kycDao-logo.svg' width={130} height={130} alt='kycDao-logo' />
         <div
-          className={`${stage == 'verified'
-            ? 'bg-[#1c6f2c] border-[#2ea043]'
-            : setKycVerified
+          className={`${
+            stage == 'verified'
+              ? 'bg-[#1c6f2c] border-[#2ea043]'
+              : setKycVerified
               ? 'bg-info  border-info-strong'
               : 'hidden'
-            } border-2 text-sm px-2 rounded-full h-6`}
+          } border-2 text-sm px-2 rounded-full h-6`}
         >
           {stage == 'verified' ? 'Approved' : 'Required'}
         </div>
@@ -127,20 +128,23 @@ const KycRequirement = ({ setKycVerified }) => {
       </div>
       <div className='font-semibold'>Verify now</div>
       <ConnectButton nav={false} needsGithub={false} centerStyles={true} tooltipAction={'start the KYC process.'} />
-      {isOnCorrectNetwork && account && <button
-        disabled={disabled}
-        className={`flex items-center gap-2 ${stage == 'start'
-          ? 'btn-requirements'
-          : stage == 'processing'
-            ? 'btn-processing cursor-not-allowed'
-            : 'btn-verified cursor-not-allowed'
+      {isOnCorrectNetwork && account && (
+        <button
+          disabled={disabled}
+          className={`flex items-center gap-2 ${
+            stage == 'start'
+              ? 'btn-requirements'
+              : stage == 'processing'
+              ? 'btn-processing cursor-not-allowed'
+              : 'btn-verified cursor-not-allowed'
           } w-fit`}
-        onClick={onOpenSDK}
-      >
-        <ShieldCheck className={'w-4 h-4 fill-primary'} />
-        {stage == 'verified' ? 'Verified' : 'Start'}
-        {stage == 'processing' && <LoadingIcon />}
-      </button>}
+          onClick={onOpenSDK}
+        >
+          <ShieldCheck className={'w-4 h-4 fill-primary'} />
+          {stage == 'verified' ? 'Verified' : 'Start'}
+          {stage == 'processing' && <LoadingIcon />}
+        </button>
+      )}
     </section>
   );
 };

--- a/components/Claim/ClaimPage/index.js
+++ b/components/Claim/ClaimPage/index.js
@@ -18,7 +18,7 @@ import ClaimButton from './ClaimButton';
 import { checkClaimable, isEveryValueNotNull, isContest } from '../../../services/utils/lib';
 // import { ChevronUpIcon, ChevronDownIcon } from '@primer/octicons-react';
 
-const ClaimPage = ({ bounty, refreshBounty, price, split, setInternalMenu, claimState, showClaimPage }) => {
+const ClaimPage = ({ bounty, refreshBounty, split, setInternalMenu, internalMenu, claimState, showClaimPage }) => {
   const [appState] = useContext(StoreContext);
 
   const { accountData, openQClient } = appState;
@@ -141,8 +141,8 @@ const ClaimPage = ({ bounty, refreshBounty, price, split, setInternalMenu, claim
               tooltipStyle={'-left-2'}
               refreshBounty={refreshBounty}
               setInternalMenu={setInternalMenu}
+              internalMenu={internalMenu}
               split={split}
-              price={price}
               setJustClaimed={setJustClaimed}
             />
 

--- a/components/Submissions/WinnerSelect.js
+++ b/components/Submissions/WinnerSelect.js
@@ -23,9 +23,9 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr, disab
   const createFixedPayout = () => {
     return prize.payout && bounty.bountyType == 3
       ? {
-          tokenAddress: bounty.payoutTokenAddress,
-          volume: prize.payout,
-        }
+        tokenAddress: bounty.payoutTokenAddress,
+        volume: prize.payout,
+      }
       : null;
   };
   const payoutBalances = useMemo(() => createFixedPayout(), [prize]);
@@ -156,9 +156,8 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr, disab
         data-testid='winnerSelect'
         onClick={selectWinner}
         disabled={prize.claimed || disabled}
-        className={`flex justify-center hover:scale-110 ${
-          prize.claimed || disabled ? 'cursor-not-allowed' : 'cursor-pointer hover:scale-200'
-        } text-black content-center items-center w-full`}
+        className={`flex justify-center hover:scale-110 ${prize.claimed || disabled ? 'cursor-not-allowed' : 'cursor-pointer hover:scale-200'
+          } text-black content-center items-center w-full`}
         style={{
           height: `${height}px`,
           transform: `translateY(${100 - height}px)`,
@@ -223,7 +222,16 @@ const WinnerSelect = ({ prize, bounty, refreshBounty, numberOfPayouts, pr, disab
             <>
               <p className='my-2'>
                 {bounty.bountyType === '2' ? prize.payout + '% of funds' : formatVolume(prize.payout) + unit} staked on
-                this competition can now be claimed by {pr.author.name || pr.author.login}.
+                this competition can now be claimed by {pr.author.name || pr.author.login},
+                <>
+                {' '}
+                  after they complete the following:
+                  <ul className='mt-2 ml-4 list-disc'>
+                    {bounty.invoiceRequired && <li>Invoice</li>}
+                    {bounty.supportingDocumentsRequired && <li>W8/W9 Form</li>}
+                    {bounty.kycRequired && <li>KYC</li>}
+                  </ul>
+                </>
               </p>
             </>
           )}

--- a/components/WalletConnect/ConnectButton.js
+++ b/components/WalletConnect/ConnectButton.js
@@ -168,7 +168,7 @@ const ConnectButton = ({ needsGithub, nav, tooltipAction, centerStyles }) => {
               outerStyles={'-top-1 '}
               groupStyles={centerStyles ? '' : 'w-min'}
               innerStyles={'sm:w-40 md:w-60 whitespace-normal'}
-              toolTipText={'Please switch to the correct network to fund this contract.'}
+              toolTipText={`Please switch to the correct network to ${tooltipAction}`}
             >
               <button
                 onClick={addOrSwitchNetwork}

--- a/pages/contract/[id]/[address].js
+++ b/pages/contract/[id]/[address].js
@@ -42,7 +42,7 @@ const address = ({ address, mergedBounty, renderError }) => {
   const [appState, dispatch] = useContext(StoreContext);
   const { accountData, openQClient } = appState;
   const [bounty, setBounty] = useState(mergedBounty);
-  const [tokenValues] = useGetTokenValues(bounty?.bountyTokenBalances);
+
   const { status } = checkClaimable(bounty, accountData?.github, openQClient);
   const claimable = status === 'Claimable';
   const claimState = useState({});
@@ -243,10 +243,10 @@ const address = ({ address, mergedBounty, renderError }) => {
 
               <BountyHeading
                 refreshGithubBounty={refreshGithubBounty}
-                price={tokenValues?.total}
                 bounty={bounty}
                 refreshBounty={refreshBounty}
                 setInternalMenu={setInternalMenu}
+                internalMenu={internalMenu}
                 split={split}
                 claimReqsCompleted={claimState[0]}
               />
@@ -263,11 +263,11 @@ const address = ({ address, mergedBounty, renderError }) => {
                 {claimable && bounty ? (
                   <ClaimPage
                     showClaimPage={internalMenu == 'Claim'}
-                    price={tokenValues?.total}
                     split={split}
                     bounty={bounty}
                     refreshBounty={refreshBounty}
                     setInternalMenu={setInternalMenu}
+                    internalMenu={internalMenu}
                     claimState={claimState}
                   />
                 ) : null}

--- a/pages/terms-of-use.js
+++ b/pages/terms-of-use.js
@@ -14,7 +14,7 @@ const TermsOfUse = () => {
           this Website are protected by copyright and trade mark law.
         </p>
         <h2 className='text-2xl font-bold py-2'>2. Use License </h2>
-        <p className='pb-4'>
+        <div className='pb-4'>
           Permission is granted to temporarily download one copy of the materials on OpenQs Website for personal,
           non-commercial transitory viewing only. This is the grant of a license, not a transfer of title, and under
           this license you may not:
@@ -29,7 +29,7 @@ const TermsOfUse = () => {
           right will also be terminated and you should destroy any downloaded materials in your possession whether it is
           printed or electronic format. These Terms of Service has been created with the help of the Terms Of Service
           Generator.
-        </p>
+        </div>
         <h2 className='text-2xl font-bold py-2'>3. Disclaimer </h2>
         <p className='pb-4'>
           All the materials on OpenQs Website are provided as is. OpenQ makes no warranties, may it be expressed or


### PR DESCRIPTION
- closes #1314 => hydration error on Terms of Use page (was related to html structure)
- closes #1310 => hasKyc is now conditional on account & chainId == 137 (Polygon Mainnet) - 
- closes #1311 => added ConnectButton so that user is prompted to use the correct network & connect wallet before the button for kyc shows - should protect us from bug in the widget itself reported in #1311 - but still, that bug was reported 10+ days ago and should also get fixed (see #1253, asked when the newest version will be available today)
- closes #1308 => adds info on which requirements still need to be fulfilled for winner to claim
- closes #1330 => fixed: price and budget seemed to be calculated asynchronously hence wrong tooltip showing
- closes #1309 => changed text that seemed ambiguous regarding the "github to wallet association" requirement and activated the claim button for it to go on the "Claim" tab to fill in all the requirements (alternative suggestion to sending the user to their profile, as it seemed more confusing from a user flow perspective - lmk if that's OK or should correct that). Claim button remains disabled when already on the right page.

![image](https://user-images.githubusercontent.com/75732239/218454361-09732a38-5ec7-4439-95f4-3fe696d1afef.png)
![image](https://user-images.githubusercontent.com/75732239/218454446-2e5c5f07-cd0c-4b2c-a35a-8cec49cc1c46.png)
![image](https://user-images.githubusercontent.com/75732239/218453902-2b458702-033a-4a86-bf85-a7c65ab45261.png)
