### PR TITLE
Miscellaneous

### DIFF
--- a/components/MintBounty/MintBountyModal/AddAlternativeMetadata/index.js
+++ b/components/MintBounty/MintBountyModal/AddAlternativeMetadata/index.js
@@ -3,6 +3,7 @@ import ToolTipNew from '../../../Utils/ToolTipNew';
 import MintContext from '../../MintContext';
 import StoreContext from '../../../../store/Store/StoreContext';
 import Image from 'next/image';
+import Link from 'next/link';
 
 const AddAlternativeMetadata = () => {
   const [githubUrl, setGithubUrl] = useState('');
@@ -45,6 +46,7 @@ const AddAlternativeMetadata = () => {
           </div>
         </ToolTipNew>
       </div>
+      <span className='note'>Enter the Github Organization URL like: <span className='underline'>https://github.com/OpenQDev</span></span>
       <input
         className='flex-1 input-field leading-loose w-full'
         id='sponsor'

--- a/components/User/OverviewTab/GithubConnection.js
+++ b/components/User/OverviewTab/GithubConnection.js
@@ -31,7 +31,7 @@ const GithubConnection = ({ user, claimPage, setVerified, setClaimPageError }) =
 
   useEffect(() => {
     const checkAssociatedAddress = async () => {
-      if (library && account && githubId) {
+      if (library && githubId) {
         try {
           const associatedAddress = await appState.openQClient.getAddressById(library, githubId);
           if (associatedAddress !== zeroAddress) {
@@ -103,7 +103,7 @@ const GithubConnection = ({ user, claimPage, setVerified, setClaimPageError }) =
                     )}
                   </span>
                 </div>
-                <div className='flex gap-2'>
+                <div className='flex gap-2 w-fit'>
                   {claimPage && hasAssociatedAddress && (
                     <div key={2} className='flex items-center gap-2 btn-verified w-fit'>
                       <Image src='/BountyMaterial/polyscan-white.png' width={20} height={20} alt='link-icon' />
@@ -121,7 +121,7 @@ const GithubConnection = ({ user, claimPage, setVerified, setClaimPageError }) =
                       btnText={
                         claimPage
                           ? [
-                              <div key={1} className='flex items-center gap-2 btn-requirements'>
+                              <div key={1} className='flex w-fit items-center gap-2 btn-requirements'>
                                 <Github className={'h-4 w-4'} />
                                 {hasAssociatedAddress ? 'Update' : 'Start'}
                               </div>,


### PR DESCRIPTION
- closes #1341 => github button with w-fit is the right size again
- removing the need for "account" to trigger "checkAssociatedAddress" (related to #1345) - but need to work on the Graph side to resolve that issue
- closes #1338 => adding a note for explicit understanding of alternative org URL

![image](https://user-images.githubusercontent.com/75732239/219002854-60e6473a-67e4-45d4-8855-280f8b3af60d.png)
![image](https://user-images.githubusercontent.com/75732239/219002660-a1b3cf5a-08e7-4732-8028-9de895541e0e.png)
 