### PR TITLE
Preparing change for associated wallet info to be read from Subgraph

### DIFF
--- a/components/User/OverviewTab/GithubConnection.js
+++ b/components/User/OverviewTab/GithubConnection.js
@@ -31,9 +31,10 @@ const GithubConnection = ({ user, claimPage, setVerified, setClaimPageError }) =
 
   useEffect(() => {
     const checkAssociatedAddress = async () => {
-      if (library && githubId) {
+      if (githubId) {
         try {
-          const associatedAddress = await appState.openQClient.getAddressById(library, githubId);
+          const associatedAddressSubgraph = await appState.openQSubgraphClient.getUserByGithubId(githubId);
+          const associatedAddress = associatedAddressSubgraph.id;
           if (associatedAddress !== zeroAddress) {
             setAssociatedAddress(associatedAddress);
             setAssociatedAddressLoading(false);
@@ -45,7 +46,7 @@ const GithubConnection = ({ user, claimPage, setVerified, setClaimPageError }) =
       }
     };
     checkAssociatedAddress();
-  }, [library, account, githubId]);
+  }, [account, githubId]);
 
   useEffect(() => {
     if (hasAssociatedAddress && githubId && claimPage) setVerified(true);


### PR DESCRIPTION
But still needs clearing that the wallet associated is unique on Graph side (currently only rendering the first associated wallet "id" in the array)


![image](https://user-images.githubusercontent.com/75732239/219118682-4c2da272-8b2e-44d7-9943-75410705db6e.png)
