### PR TITLE
Mini fix

### DIFF
--- a/components/Explore/Header.js
+++ b/components/Explore/Header.js
@@ -32,6 +32,7 @@ export default function Header() {
         alt=''
         width={571}
         height={587}
+        priority={true}
       />
     </header>
   );


### PR DESCRIPTION
- closes #1353 => (deprecated warnings had already been fixed apparently) fixes minor new warning, but the other image-related warning seems to be a known bug not fixed yet from next/image: https://github.com/vercel/next.js/issues/40762

![image](https://user-images.githubusercontent.com/75732239/219704510-0ef6ee37-4a9c-42a6-8d91-986a21ea5ee2.png)
