### PR TITLE
Adding messages to tell user that they need to confirm via wallet

### DIFF
--- a/components/AdminPage/AdminModal/index.js
+++ b/components/AdminPage/AdminModal/index.js
@@ -191,6 +191,9 @@ const AdminModal = ({ setModal, modal, bounty, tokenAddress }) => {
 
             {modal.type === 'Loading' && (
               <>
+                <div className='bg-info border-info-strong border-2 p-3 rounded-sm mb-4'>
+                  Please confirm this transaction via your wallet!
+                </div>
                 <div className='flex items-center gap-2'>
                   Your request is being processed... <LoadingIcon />
                 </div>

--- a/components/Claim/ClaimLoadingModal/ClaimLoadingModal.test.js
+++ b/components/Claim/ClaimLoadingModal/ClaimLoadingModal.test.js
@@ -60,7 +60,7 @@ describe('ClaimLoadingModal', () => {
     expect(nullish).toHaveLength(0);
   });
 
-  it('should display inelgible', async () => {
+  it('should display ineligible', async () => {
     // ARRANGE
     const claimBounty = jest.fn();
     const url = 'www.example.com';

--- a/components/Claim/ClaimPage/index.js
+++ b/components/Claim/ClaimPage/index.js
@@ -111,7 +111,7 @@ const ClaimPage = ({ bounty, refreshBounty, split, setInternalMenu, internalMenu
                 'Congratulations, you can now claim your bounty!'
               ) : (
                 <>
-                  Congratulations, you are elgible to receive this bounty! In order to claim it you need to fulfill the
+                  Congratulations, you are eligible to receive this bounty! In order to claim it you need to fulfill the
                   requirements highlighted below. To learn more read{' '}
                   <Link
                     href='https://docs.openq.dev/hackathon-winner/preparing-to-claim'

--- a/components/FundBounty/ApproveFundModal/index.js
+++ b/components/FundBounty/ApproveFundModal/index.js
@@ -220,6 +220,11 @@ const ApproveFundModal = ({
         </div>
       ) : (
         <>
+          {(approveTransferState === 'APPROVING' || approveTransferState === 'TRANSFERRING') && (
+            <div className='bg-info border-info-strong border-2 p-3 rounded-sm mb-4'>
+              Please confirm this transaction via your wallet!
+            </div>
+          )}
           <div className='gap-4 grid grid-cols-[150px_1fr]'>
             <div>Deposit:</div>
             <div className='flex  gap-4'>

--- a/components/MintBounty/MintBountyModal/MintBountyModalButton/MintBountyModalButton.test.js
+++ b/components/MintBounty/MintBountyModal/MintBountyModalButton/MintBountyModalButton.test.js
@@ -97,7 +97,7 @@ it('should show "choose eligible issue" when on correct network, minted, and sta
   );
 
   expect(screen.getAllByRole('button', { name: 'Deploy Contract' })[0].disabled).toBe(true);
-  const tooltip = screen.getAllByText(/Please choose an elgible issue./i);
+  const tooltip = screen.getAllByText(/Please choose an eligible issue./i);
   expect(tooltip[0]).toBeInTheDocument();
 });
 

--- a/components/MintBounty/MintBountyModal/MintBountyModalButton/index.js
+++ b/components/MintBounty/MintBountyModal/MintBountyModalButton/index.js
@@ -177,7 +177,7 @@ const MintBountyModalButton = ({ modalVisibility, setError }) => {
             issue?.closed && issue?.url?.includes('/issues/')
               ? 'Issue closed'
               : !enableMint || !issue?.url?.includes('/issues/')
-              ? 'Please choose an elgible issue.'
+              ? 'Please choose an eligible issue.'
               : !datesCheck
               ? 'Please make sure your Hackathon Start Date is > today and your End Date after your Start Date.'
               : !loggedInIfNeeded

--- a/components/MintBounty/MintBountyModal/MintBountyModalButton/index.js
+++ b/components/MintBounty/MintBountyModal/MintBountyModalButton/index.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 
 import { useRouter } from 'next/router';
 import useIsOnCorrectNetwork from '../../../../hooks/useIsOnCorrectNetwork';
@@ -9,11 +9,13 @@ import ToolTipNew from '../../../Utils/ToolTipNew';
 import ConnectButton from '../../../WalletConnect/ConnectButton';
 import MintContext from '../../MintContext';
 import { checkHackathonDates } from '../../../../services/utils/lib';
+import ConfirmTransactionModal from '../../../Utils/ConfirmTransactionModal';
 
 // TODO: Put all this state logic into a context, and possibly add a reducer
 const MintBountyModalButton = ({ modalVisibility, setError }) => {
   const [isOnCorrectNetwork] = useIsOnCorrectNetwork();
   const [mintState, mintDispatch] = useContext(MintContext);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const {
     goalToken,
@@ -82,6 +84,7 @@ const MintBountyModalButton = ({ modalVisibility, setError }) => {
   };
 
   const mintBounty = async () => {
+    setShowConfirm(true);
     try {
       const dispatch = { type: 'SET_LOADING', payload: true };
       mintDispatch(dispatch);
@@ -132,6 +135,7 @@ const MintBountyModalButton = ({ modalVisibility, setError }) => {
         altUrl,
         data
       );
+      setShowConfirm(false);
       if (enableRegistration && datesCheck) {
         await appState.openQPrismaClient.setIsContest({
           github,
@@ -157,6 +161,7 @@ const MintBountyModalButton = ({ modalVisibility, setError }) => {
       const { message, title } = appState.openQClient.handleError(error);
       appState.logger.error(error, accountData.id, 'MintBountyModalButton.js1');
       setError({ message, title });
+      setShowConfirm(false);
     }
   };
 
@@ -198,6 +203,7 @@ const MintBountyModalButton = ({ modalVisibility, setError }) => {
           </button>
         </ToolTipNew>
       )}
+      {showConfirm && <ConfirmTransactionModal setShowConfirm={setShowConfirm} />}
     </>
   );
 };

--- a/components/RefundBounty/ApproveTransferModal.js
+++ b/components/RefundBounty/ApproveTransferModal.js
@@ -139,6 +139,11 @@ const ApproveTransferModal = ({
     >
       {/* Body */}
       <>
+        {approveTransferState == 'APPROVING' && (
+          <div className='bg-info border-info-strong border-2 p-3 rounded-sm mb-4'>
+            Please confirm this transaction via your wallet!
+          </div>
+        )}
         <div className='gap-4 grid grid-cols-[150px_1fr]'>
           <div>Deposit:</div>
           <div className='flex gap-2'>

--- a/components/Submissions/WinnerSelectAmounts.js
+++ b/components/Submissions/WinnerSelectAmounts.js
@@ -227,9 +227,14 @@ const WinnerSelectAmounts = ({ prize, bounty, refreshBounty, pr, disabled, isRem
             </>
           )}
           {selectionState === TRANSFERRING && (
-            <div className='flex items-center gap-2'>
-              Your request is being processed... <LoadingIcon />
-            </div>
+            <>
+              <div className='bg-info border-info-strong border-2 p-3 rounded-sm mb-4'>
+                Please confirm this transaction via your wallet!
+              </div>
+              <div className='flex items-center gap-2'>
+                Your request is being processed... <LoadingIcon />
+              </div>
+            </>
           )}
           {selectionState === ERROR && <p>{error.message}</p>}
           {selectionState === SUCCESS && (

--- a/components/Utils/ConfirmTransactionModal.js
+++ b/components/Utils/ConfirmTransactionModal.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ModalDefault from './ModalDefault';
+
+const ConfirmTransactionModal = ({ setShowConfirm }) => {
+  return (
+    <>
+      <ModalDefault
+        title='Requesting Your Confirmation'
+        setShowModal={setShowConfirm} /*resetState={setAssociateState} */
+      >
+        <div className='whitespace-pre-wrap'>Please confirm this transaction via your wallet.</div>
+      </ModalDefault>
+    </>
+  );
+};
+
+export default ConfirmTransactionModal;

--- a/components/Utils/ConfirmTransactionModal.js
+++ b/components/Utils/ConfirmTransactionModal.js
@@ -4,10 +4,7 @@ import ModalDefault from './ModalDefault';
 const ConfirmTransactionModal = ({ setShowConfirm }) => {
   return (
     <>
-      <ModalDefault
-        title='Requesting Your Confirmation'
-        setShowModal={setShowConfirm} /*resetState={setAssociateState} */
-      >
+      <ModalDefault title='Requesting Your Confirmation' setShowModal={setShowConfirm}>
         <div className='whitespace-pre-wrap'>Please confirm this transaction via your wallet.</div>
       </ModalDefault>
     </>

--- a/components/Utils/ModalDefault.js
+++ b/components/Utils/ModalDefault.js
@@ -14,8 +14,10 @@ const ModalDefault = ({ title, children, footerLeft, footerRight, setShowModal, 
     // Courtesy of https://stackoverflow.com/questions/32553158/detect-click-outside-react-component
     function handleClickOutside(event) {
       if (modal.current && !modal?.current.contains(event.target)) {
+        if (typeof resetState === 'function') {
+          resetState();
+        }
         setShowModal(false);
-        resetState();
       }
     }
 

--- a/test-utils/constant.js
+++ b/test-utils/constant.js
@@ -926,7 +926,7 @@ export default class Constants {
   static get bountyClaimOverview() {
     return {
       id: 'I_kwDOGWnnz85Z_0oY',
-      title: 'Checking no elgible prs',
+      title: 'Checking no eligible prs',
       assignees: [],
       body: '',
       url: 'https://github.com/OpenQDev/OpenQ-TestRepo/issues/792',
@@ -938,7 +938,7 @@ export default class Constants {
       createdAt: '2022-12-24T01:53:30Z',
       closed: true,
       bodyHTML: '',
-      titleHTML: 'Checking no elgible prs',
+      titleHTML: 'Checking no eligible prs',
       twitterUsername: 'openqlabs',
       number: 792,
       prs: [


### PR DESCRIPTION
- closes #1531 - on mintbounty it adds a modal just for the time when the user needs to confirm via wallet, on other modals it adds a message for this

![image](https://user-images.githubusercontent.com/75732239/225950097-741a3835-aa6f-46f0-b369-42d6ca004080.png)
![image](https://user-images.githubusercontent.com/75732239/225950232-7e650456-72b6-481a-bb81-aa8cc0ee94cf.png)

