### PR TITLE
Fixed issue where knock wasn't working on firefox, and uses dark theme

### DIFF
--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -26,8 +26,11 @@ const Navigation = () => {
 
   useEffect(() => {
     const getNotificationCookie = async () => {
-      const signedKnockTokenCookie = await window?.cookieStore?.get('signed_knock_token');
-      setNotificationToken(signedKnockTokenCookie?.value);
+      // regex for signed_knock_token cookie
+      const signedKnockTokenCookie = document.cookie.match(/(signed_knock_token=)(.*?)+/)[0].slice(19);
+
+      console.log(signedKnockTokenCookie);
+      setNotificationToken(signedKnockTokenCookie);
     };
 
     getNotificationCookie();

--- a/components/Notifications/NotificationBell.js
+++ b/components/Notifications/NotificationBell.js
@@ -15,6 +15,7 @@ const NotificationBell = ({ userId, notificationToken }) => {
 
   return (
     <KnockFeedProvider
+      colorMode='dark'
       apiKey={process.env.NEXT_PUBLIC_NOTIFICATIONS_PUBLIC_KEY}
       feedId={process.env.NEXT_PUBLIC_NOTIFICATIONS_CHANNEL_ID}
       userToken={notificationToken}
@@ -24,6 +25,7 @@ const NotificationBell = ({ userId, notificationToken }) => {
         <NotificationIconButton ref={notifButtonRef} onClick={() => setIsVisible(!isVisible)} />
         <NotificationFeedPopover
           buttonRef={notifButtonRef}
+          className='bg-red-500'
           isVisible={isVisible}
           onNotificationClick={(item) => notificationClicked(item)}
           onClose={() => setIsVisible(false)}


### PR DESCRIPTION

Closes #1681 
Also manually parses cookie because cookieStore is not supported by firefox.