### PR TITLE
Fix issue that was causing bounty duplicates & improve claim progress

### DIFF
--- a/components/Claim/ClaimsTracking/ClaimsPerBounty/IndividualClaim/index.js
+++ b/components/Claim/ClaimsTracking/ClaimsPerBounty/IndividualClaim/index.js
@@ -11,7 +11,6 @@ const IndividualClaim = ({
   gridFormat,
   setFilteredTiers,
   filteredTiers,
-  setFilteredCount,
   setFilteredInfo,
   filteredInfo,
   filters,
@@ -112,7 +111,6 @@ const IndividualClaim = ({
       setHide('');
     }
     setFilteredTiers(newFilteredTiers);
-    setFilteredCount(newCount);
     newFilteredInfo[bounty.id] = { filteredCount: newCount };
     setFilteredInfo({ ...filteredInfo, ...newFilteredInfo });
   }, [filters, githubCondition, claimCondition, w8Condition, kycCondition, walletCondition]);

--- a/components/Claim/ClaimsTracking/ClaimsPerBounty/index.js
+++ b/components/Claim/ClaimsTracking/ClaimsPerBounty/index.js
@@ -6,11 +6,10 @@ import IndividualClaim from './IndividualClaim';
 const ClaimsPerBounty = ({ item, filters, setFilteredInfo, filteredInfo }) => {
   const gridFormat = 'grid grid-cols-[2.5fr_1fr_0.75fr_0.5fr_0.75fr_0.5fr]';
   const [filteredTiers, setFilteredTiers] = useState(Array(item.payoutSchedule?.length).fill(true));
-  const [filteredCount, setFilteredCount] = useState(0);
   return (
     <div
       className={`${
-        filteredCount == 0 && 'hidden'
+        filteredInfo[item.id]?.filteredCount == 0 && 'hidden'
       } flex flex-col mb-4 lg:min-w-[1000px] overflow-x-auto border border-web-gray rounded-sm p-4`}
     >
       <div className='flex items-center gap-4 mb-2'>
@@ -47,7 +46,6 @@ const ClaimsPerBounty = ({ item, filters, setFilteredInfo, filteredInfo }) => {
               filters={filters}
               setFilteredTiers={setFilteredTiers}
               filteredTiers={filteredTiers}
-              setFilteredCount={setFilteredCount}
               setFilteredInfo={setFilteredInfo}
               filteredInfo={filteredInfo}
             />

--- a/components/Claim/ClaimsTracking/index.js
+++ b/components/Claim/ClaimsTracking/index.js
@@ -37,7 +37,6 @@ const ClaimsTracking = ({ fetchFilters, TVLBalances, payoutBalances }) => {
   const TVLObj = useMemo(() => createTVLObj(TVLBalances), [TVLBalances]);
   const [TVLValues] = useGetTokenValues(TVLObj);
   const TVL = TVLValues?.total;
-  console.log('TVL', TVL);
 
   const createPayoutObj = (payoutBalances) => {
     return payoutBalances.map((item) => {
@@ -47,7 +46,6 @@ const ClaimsTracking = ({ fetchFilters, TVLBalances, payoutBalances }) => {
   const payoutObj = useMemo(() => createPayoutObj(payoutBalances), [payoutBalances]);
   const [payoutValues] = useGetTokenValues(payoutObj);
   const payout = payoutValues?.total;
-  console.log('payout', payout);
 
   useEffect(() => {
     setLoadingBounties(true);
@@ -91,18 +89,14 @@ const ClaimsTracking = ({ fetchFilters, TVLBalances, payoutBalances }) => {
   useEffect(() => {
     let newCountAll = 0;
     let newNbPayouts = 0;
-    let newBountyCount = 0;
     setLoading(true);
     //let newPrizeObj = {};
-    if (initialItems.length > 0) {
+    if (initialItems?.length > 0) {
       newNbPayouts = initialItems.reduce((acc, item) => {
         newCountAll += item.payoutSchedule?.length || 0;
         return acc + (item.payouts?.length || 0);
       }, 0);
-      newBountyCount = initialItems.reduce((acc) => {
-        return acc + 1;
-      }, 0);
-      setBountyCount(newBountyCount);
+      setBountyCount(initialItems.length);
       setNbPayouts(newNbPayouts);
       setCountAll(newCountAll);
       setLoading(false);

--- a/components/Claim/ClaimsTracking/index.js
+++ b/components/Claim/ClaimsTracking/index.js
@@ -62,6 +62,7 @@ const ClaimsTracking = ({ fetchFilters, TVLBalances, payoutBalances }) => {
         nodes = [...nodes, ...newNodes];
         cursor = newCursor;
         complete = newComplete;
+        console.log('while loop claim progress - nodes, cursor, complete', nodes, cursor, complete);
       }
       setInitialItems(nodes);
       setFilteredItems(nodes);
@@ -75,6 +76,18 @@ const ClaimsTracking = ({ fetchFilters, TVLBalances, payoutBalances }) => {
     const newFilteredItems = filtering(initialItems, filters);
     setFilteredItems(newFilteredItems);
   }, [filters]);
+
+  useEffect(() => {
+    Object.keys(filteredInfo).forEach((id) => {
+      if (!filteredItems.some((item) => item.id == id)) {
+        let newFilteredInfo = filteredInfo;
+        newFilteredInfo[id].filteredCount = 0;
+        return setFilteredInfo({ ...filteredInfo, ...newFilteredInfo });
+      }
+    });
+  }, [filteredItems]);
+
+  console.log('filteredInfo', filteredInfo);
 
   useEffect(() => {
     let newTierAmount = 0;

--- a/components/Claim/ClaimsTracking/index.js
+++ b/components/Claim/ClaimsTracking/index.js
@@ -62,7 +62,6 @@ const ClaimsTracking = ({ fetchFilters, TVLBalances, payoutBalances }) => {
         nodes = [...nodes, ...newNodes];
         cursor = newCursor;
         complete = newComplete;
-        console.log('while loop claim progress - nodes, cursor, complete', nodes, cursor, complete);
       }
       setInitialItems(nodes);
       setFilteredItems(nodes);
@@ -86,8 +85,6 @@ const ClaimsTracking = ({ fetchFilters, TVLBalances, payoutBalances }) => {
       }
     });
   }, [filteredItems]);
-
-  console.log('filteredInfo', filteredInfo);
 
   useEffect(() => {
     let newTierAmount = 0;

--- a/services/utils/Utils.js
+++ b/services/utils/Utils.js
@@ -156,8 +156,7 @@ class Utils {
       const subgraphBounty = subgraphBounties.find((bounty) => {
         return contract.address?.toLowerCase() === bounty.bountyAddress;
       });
-
-      if (relatedIssue && contract && !contract.blacklisted) {
+      if (relatedIssue && subgraphBounty && !contract.blacklisted) {
         let mergedBounty = {
           alternativeName: '',
           alternativeLogo: '',


### PR DESCRIPTION
- Fix: fetching of fullBounties in FE was not filtered by subgraph bounties (condition was wrong) which is why we had duplicates (as per the API bountylist that has several bounties with the same bountyId but different contract addresses not presence on the graph)

- simplify bounty count & improve tier count on filtering for the Hackathon overview